### PR TITLE
fix: ensure locales are loaded from relative path

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -30,6 +30,10 @@ i18n
     ns: ['status', 'files', 'explore', 'peers', 'settings'],
     fallbackLng: 'en',
     debug: process.env.NODE_ENV !== 'production',
+    backend: {
+      // ensure a realtive path is used to look up the locales, so it works when used from /ipfs/<cid>
+      loadPath: 'locales/{{lng}}/{{ns}}.json'
+    },
     // react i18next special options (optional)
     react: {
       wait: true,


### PR DESCRIPTION
Otherwise the locale requests fail when app is mounted
at /ipfs or /ipns

License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>