### PR TITLE
[WIP] chore: drop refs for files

### DIFF
--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -183,7 +183,7 @@ export class FilesList extends React.Component {
 
     if (e.key === ' ' && focused !== null && focused !== -1) {
       e.preventDefault()
-      return this.toggleOne(focused, true)
+      return this.toggleOne(files[focused].name, true)
     }
 
     if ((e.key === 'Enter' || (e.key === 'ArrowRight' && e.metaKey)) && focused !== null) {
@@ -205,11 +205,6 @@ export class FilesList extends React.Component {
       if (index >= -1 && index < files.length) {
         console.log('index', index)
         this.setState({ focused: index })
-
-        // this.listRef.current.scrollToRow(index)
-        // const domNode = findDOMNode(this.filesRefs[name])
-        // domNode.scrollIntoView({ behaviour: 'smooth', block: 'center' })
-        // domNode.querySelector('input[type="checkbox"]').focus()
       }
 
       this.listRef.current.forceUpdateGrid()

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -62,6 +62,7 @@ export class FilesList extends React.Component {
   state = {
     selected: [],
     focused: null,
+    scrollToIndex: -1,
     isDragging: false,
     contextMenu: {
       isOpen: false,
@@ -183,6 +184,7 @@ export class FilesList extends React.Component {
 
     if (e.key === ' ' && focused !== null && focused !== -1) {
       e.preventDefault()
+      this.setState({ scrollToIndex: focused })
       return this.toggleOne(files[focused].name, true)
     }
 
@@ -203,8 +205,7 @@ export class FilesList extends React.Component {
       }
 
       if (index >= -1 && index < files.length) {
-        console.log('index', index)
-        this.setState({ focused: index })
+        this.setState({ focused: index, scrollToIndex: index })
       }
 
       this.listRef.current.forceUpdateGrid()
@@ -401,7 +402,7 @@ export class FilesList extends React.Component {
 
   render () {
     let { t, files, className, upperDir, showLoadingAnimation, connectDropTarget } = this.props
-    const { selected } = this.state
+    const { selected, scrollToIndex } = this.state
     const allSelected = selected.length !== 0 && selected.length === files.length
     const rowCount = files.length && upperDir ? files.length + 1 : files.length
     const checkBoxCls = classnames({
@@ -450,6 +451,7 @@ export class FilesList extends React.Component {
                         onRowsRendered={this.onRowsRendered}
                         isScrolling={isScrolling}
                         onScroll={onChildScroll}
+                        scrollToIndex={scrollToIndex}
                         scrollTop={scrollTop} />
                     )}
                   </AutoSizer>


### PR DESCRIPTION
This PR removes the files refs and uses the [`scrollToIndex`](https://github.com/bvaughn/react-virtualized/blob/master/docs/List.md#prop-types) prop to scroll to the desired row when using the keyboard navigation.

The `scrollToIndex` isn't working with WindowScroller, I've found [various](https://github.com/bvaughn/react-virtualized/issues/1226)  related [issues](https://github.com/bvaughn/react-virtualized/issues/1179).

Here are two examples demonstrating the problem:

✅ without WindowScroller: https://codesandbox.io/s/y23390y9yx
❌ with WindowScroller: https://codesandbox.io/s/1zjovmyy2j

When it gets fixed this PR should be unblocked!