### PR TITLE
patch tiny-secp256k1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6540,7 +6540,7 @@
         "bs58check": "^2.1.1",
         "create-hash": "^1.2.0",
         "create-hmac": "^1.1.7",
-        "tiny-secp256k1": "^1.1.3",
+        "tiny-secp256k1": "dignifiedquire/tiny-secp256k1",
         "typeforce": "^1.11.5",
         "wif": "^2.0.6"
       },
@@ -6551,15 +6551,7 @@
           "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
         },
         "tiny-secp256k1": {
-          "version": "1.1.5",
-          "resolved": "dignifiedquire/tiny-secp256k1",
-          "requires": {
-            "bindings": "^1.3.0",
-            "bn.js": "^4.11.8",
-            "create-hmac": "^1.1.7",
-            "elliptic": "^6.4.0",
-            "nan": "^2.13.2"
-          }
+          "version": "dignifiedquire/tiny-secp256k1"
         }
       }
     },
@@ -6592,22 +6584,14 @@
         "merkle-lib": "^2.0.10",
         "pushdata-bitcoin": "^1.0.1",
         "randombytes": "^2.0.1",
-        "tiny-secp256k1": "^1.1.1",
+        "tiny-secp256k1": "dignifiedquire/tiny-secp256k1",
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.0.4",
         "wif": "^2.0.1"
       },
       "dependencies": {
         "tiny-secp256k1": {
-          "version": "1.1.5",
-          "resolved": "dignifiedquire/tiny-secp256k1",
-          "requires": {
-            "bindings": "^1.3.0",
-            "bn.js": "^4.11.8",
-            "create-hmac": "^1.1.7",
-            "elliptic": "^6.4.0",
-            "nan": "^2.13.2"
-          }
+          "version": "dignifiedquire/tiny-secp256k1"
         }
       }
     },
@@ -18598,7 +18582,7 @@
       "integrity": "sha512-iKXdzGnPsz3slh6Gm9oNj0h0X37f/YFuSkg7MikQgrx5l5XRaFRxVDoqbsTlQ5nIS02tGuLJvmbqpLOZ+aWVow==",
       "dev": true,
       "requires": {
-        "bcrypto": "5.1.0",
+        "bcrypto": "dignifiedquire/bcrypto",
         "buffer": "^5.4.3",
         "debug": "^4.1.1",
         "it-buffer": "^0.1.1",
@@ -18612,9 +18596,7 @@
       },
       "dependencies": {
         "bcrypto": {
-          "version": "5.3.0",
-          "resolved": "dignifiedquire/bcrypto",
-          "dev": true
+          "version": "dignifiedquire/bcrypto"
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -6461,16 +6461,6 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "bcrypto": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.1.0.tgz",
-      "integrity": "sha512-WEs5g7WHdEdLLcsvhE7Z1AXv0G+hb+bJhSUYM7samFNrH051XhcFVWxAbAZDmIU1HWjpjhmQ+HqBar7UC/qrzQ==",
-      "dev": true,
-      "requires": {
-        "bufio": "~1.0.6",
-        "loady": "~0.0.1"
-      }
-    },
     "bech32": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
@@ -7022,12 +7012,6 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
       "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
-      "dev": true
-    },
-    "bufio": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
-      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==",
       "dev": true
     },
     "builtin-status-codes": {
@@ -18625,6 +18609,13 @@
         "libp2p-crypto": "^0.17.6",
         "peer-id": "^0.13.5",
         "protobufjs": "6.8.8"
+      },
+      "dependencies": {
+        "bcrypto": {
+          "version": "5.3.0",
+          "resolved": "dignifiedquire/bcrypto",
+          "dev": true
+        }
       }
     },
     "libp2p-pubsub": {
@@ -18993,12 +18984,6 @@
           }
         }
       }
-    },
-    "loady": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
-      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==",
-      "dev": true
     },
     "locate-path": {
       "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6559,6 +6559,17 @@
           "version": "10.12.18",
           "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
           "integrity": "sha512-fh+pAqt4xRzPfqA6eh3Z2y6fyZavRIumvjhaCL753+TVkGKGhpPeyrJG2JftD0T9q4GF00KjefsQ+PQNDdWQaQ=="
+        },
+        "tiny-secp256k1": {
+          "version": "1.1.5",
+          "resolved": "dignifiedquire/tiny-secp256k1",
+          "requires": {
+            "bindings": "^1.3.0",
+            "bn.js": "^4.11.8",
+            "create-hmac": "^1.1.7",
+            "elliptic": "^6.4.0",
+            "nan": "^2.13.2"
+          }
         }
       }
     },
@@ -6595,6 +6606,19 @@
         "typeforce": "^1.11.3",
         "varuint-bitcoin": "^1.0.4",
         "wif": "^2.0.1"
+      },
+      "dependencies": {
+        "tiny-secp256k1": {
+          "version": "1.1.5",
+          "resolved": "dignifiedquire/tiny-secp256k1",
+          "requires": {
+            "bindings": "^1.3.0",
+            "bn.js": "^4.11.8",
+            "create-hmac": "^1.1.7",
+            "elliptic": "^6.4.0",
+            "nan": "^2.13.2"
+          }
+        }
       }
     },
     "bl": {
@@ -26709,18 +26733,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
       "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
-    },
-    "tiny-secp256k1": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tiny-secp256k1/-/tiny-secp256k1-1.1.5.tgz",
-      "integrity": "sha512-duE2hSLSQIpHGzmK48OgRrGTi+4OTkXLC6aa86uOYQ6LLCYZSarVKIAvEtY7MoXjoL6bOXMSerEGMzrvW4SkDw==",
-      "requires": {
-        "bindings": "^1.3.0",
-        "bn.js": "^4.11.8",
-        "create-hmac": "^1.1.7",
-        "elliptic": "^6.4.0",
-        "nan": "^2.13.2"
-      }
     },
     "tiny-warning": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009 -s public",
     "build-storybook": "build-storybook -s public",
-    "check": "tsc --noEmit"
+    "check": "tsc --noEmit",
+    "preinstall": "npx npm-force-resolutions"
   },
   "dependencies": {
     "@tableflip/react-dropdown": "^1.3.0",
@@ -156,5 +157,8 @@
       "^react-dnd$": "react-dnd/dist/cjs",
       "^react-dnd-html5-backend$": "react-dnd-html5-backend/dist/cjs"
     }
+  },
+  "resolutions": {
+    "tiny-secp256k1": "dignifiedquire/tiny-secp256k1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -159,6 +159,7 @@
     }
   },
   "resolutions": {
-    "tiny-secp256k1": "dignifiedquire/tiny-secp256k1"
+    "tiny-secp256k1": "dignifiedquire/tiny-secp256k1",
+    "bcrypto": "dignifiedquire/bcrypto"
   }
 }


### PR DESCRIPTION
Uses https://github.com/bitcoinjs/tiny-secp256k1/pull/49 to avoid build issues on macos