### PR TITLE
fix: clicking in advanced section content no longer closes it

### DIFF
--- a/src/components/details/Details.js
+++ b/src/components/details/Details.js
@@ -4,11 +4,12 @@ import 'details-polyfill'
 const Details = ({
   summaryText = 'Advanced',
   children,
+  onClick,
   ...props
 }) => {
   return (
     <details {...props}>
-      <summary className='pointer blue outline-0'>{summaryText}</summary>
+      <summary className='pointer blue outline-0' onClick={onClick}>{summaryText}</summary>
       {children}
     </details>
   )


### PR DESCRIPTION
Fixes https://github.com/ipfs/ipfs-webui/issues/1693