### PR TITLE
fix: dnd to a dir with escaped characters

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,6 +26,7 @@ export class App extends Component {
     doUpdateHash: PropTypes.func.isRequired,
     doFilesWrite: PropTypes.func.isRequired,
     routeInfo: PropTypes.object.isRequired,
+    filesPathInfo: PropTypes.object,
     // Injected by DropTarget
     isOver: PropTypes.bool.isRequired
   }
@@ -35,9 +36,9 @@ export class App extends Component {
   }
 
   addFiles = async (filesPromise) => {
-    const { doFilesWrite, doUpdateHash, routeInfo } = this.props
+    const { doFilesWrite, doUpdateHash, routeInfo, filesPathInfo } = this.props
     const isFilesPage = routeInfo.pattern === '/files*'
-    const addAtPath = isFilesPage ? routeInfo.params.path : '/'
+    const addAtPath = isFilesPage ? (filesPathInfo?.realPath || routeInfo.params.path) : '/'
     const files = await filesPromise
 
     doFilesWrite(normalizeFiles(files), addAtPath)

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -306,8 +306,10 @@ const actions = () => ({
           try {
             await ipfs.files.cp(src, dst)
           } catch (err) {
-            throw Object.assign(new Error('Folder already exists.'), {
-              code: 'ERR_FOLDER_EXISTS'
+            // TODO: Not sure why we do this. Perhaps a generic error is used
+            // to avoid leaking private information via Countly?
+            throw Object.assign(new Error('ipfs.files.cp call failed'), {
+              code: 'ERR_FILES_CP_FAILED'
             })
           }
         }


### PR DESCRIPTION
Seems that this never worked with drag&drop because webui used path from URL as-is.
This PR fixes it by using url-decoded `realPath` after being processed by `src/bundles/files/utils.js#infoFromPath` 

Closes https://github.com/ipfs/ipfs-webui/issues/1733