### PR TITLE
fix: do not send consent removal event

### DIFF
--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -33,7 +33,11 @@ function createStore (analyticsOpts = {}) {
 it('should disable analytics by default', () => {
   const store = createStore()
   expect(store.selectAnalyticsEnabled()).toBe(false)
+  // no events will be sent as no consents have been given
   expect(store.selectAnalyticsConsent()).toEqual([])
+  // user has not explicitly opted in or out yet
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
 })
 
 it('should enable analytics if user has explicitly enabled it', () => {
@@ -41,6 +45,9 @@ it('should enable analytics if user has explicitly enabled it', () => {
   store.doEnableAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
 })
 
 it('should disable analytics if user has explicitly disabled it', () => {
@@ -48,6 +55,9 @@ it('should disable analytics if user has explicitly disabled it', () => {
   store.doDisableAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(false)
   expect(store.selectAnalyticsConsent()).toEqual([])
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).toHaveBeenCalled()
+  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
 })
 
 it('should enable selectAnalyticsAskToEnable if user has not explicity enabled or disabled it', () => {
@@ -79,10 +89,20 @@ it('should toggle analytics', () => {
   store.doToggleAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(false)
   expect(store.selectAnalyticsConsent()).toEqual([])
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).toHaveBeenCalled()
+  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
 })
 
 it('should toggle consent', () => {
@@ -91,29 +111,68 @@ it('should toggle consent', () => {
   store.doToggleConsent('crashes')
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['crashes'])
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(false)
   expect(store.selectAnalyticsConsent()).toEqual([])
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).toHaveBeenCalled()
+  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleConsent('sessions')
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['events', 'views', 'location'])
+  // changing the consents should not opt/in or out
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleConsent('location')
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['events', 'views'])
+  // changing the consents should not opt/in or out
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   store.doToggleConsent('views')
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['events'])
+  // changing the consents should not opt/in or out
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 
   // Removing all consent is equivalent to disabling the analytics.
   store.doToggleConsent('events')
   expect(store.selectAnalyticsEnabled()).toBe(false)
   expect(store.selectAnalyticsConsent()).toEqual([])
+  expect(global.Countly.opt_in).not.toHaveBeenCalled()
+  expect(global.Countly.opt_out).toHaveBeenCalled()
+  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
 })


### PR DESCRIPTION
- Saying no to analytics explicitly calls `Countly.opt_out`. Without this removing all consents triggers a "consent removed" event to be tracked which is not what we want.
- Removing all individual consents explicitly calls `Countly.opt_out`
- Granting consent for 1 or more analytic types opts back in to analytics by calling `Countly.opt_in`.
- Saying yes to analytics explicitly calls `Countly.opt_in`, for completeness.

ref: https://github.com/ipfs/ipfs-webui/issues/1041#issuecomment-825770656


License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>