### PR TITLE
fix: work around dot in pin service name

### DIFF
--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -20,7 +20,12 @@ const parseService = async (service, remoteServiceTemplates, ipfs) => {
 }
 
 const mfsPolicyEnableFlag = memoize(async (serviceName, ipfs) => {
-  return await ipfs.config.get(`Pinning.RemoteServices.${serviceName}.Policies.MFS.Enable`)
+  try {
+    return await ipfs.config.get(`Pinning.RemoteServices.${serviceName}.Policies.MFS.Enable`)
+  } catch (e) {
+    console.error(`unexpected config.get error for "${serviceName}"`, e)
+    return false
+  }
 }, { maxAge: 3000 })
 
 const uniqueCidBatches = (arrayOfCids, size) => {
@@ -222,6 +227,9 @@ const pinningBundle = {
   },
   doAddPinningService: ({ apiEndpoint, nickname, secretApiKey }) => async ({ getIpfs }) => {
     const ipfs = getIpfs()
+
+    // temporary mitigation for https://github.com/ipfs/ipfs-webui/issues/1770
+    nickname = nickname.replaceAll('.', '_')
 
     await ipfs.pin.remote.service.add(nickname, {
       endpoint: apiEndpoint,

--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -23,9 +23,14 @@ const mfsPolicyEnableFlag = memoize(async (serviceName, ipfs) => {
   try {
     return await ipfs.config.get(`Pinning.RemoteServices.${serviceName}.Policies.MFS.Enable`)
   } catch (e) {
-    console.error(`unexpected config.get error for "${serviceName}"`, e)
-    return false
+    if (e.message?.includes('key has no attribute')) {
+      try { // retry with notation from https://github.com/ipfs/go-ipfs/pull/8096
+        return await ipfs.config.get(`Pinning.RemoteServices["${serviceName}"].Policies.MFS.Enable`)
+      } catch (_) {}
+    }
+    console.error(`unexpected config.get error for "${serviceName}": ${e.message}`)
   }
+  return false
 }, { maxAge: 3000 })
 
 const uniqueCidBatches = (arrayOfCids, size) => {

--- a/src/components/pinning-manager/PinningManager.js
+++ b/src/components/pinning-manager/PinningManager.js
@@ -163,6 +163,8 @@ const OptionsCell = ({ doRemovePinningService, name, visitServiceUrl, autoUpload
     setContextVisibility(false)
   }
 
+  const showAutoUpload = !name.includes('.') // temporary mitigation for https://github.com/ipfs/ipfs-webui/issues/1770
+
   return (
     <div>
       <button className="button-inside-focus" onClick={() => setContextVisibility(true)} ref={buttonRef} aria-label={t('showOptions')}>
@@ -170,9 +172,11 @@ const OptionsCell = ({ doRemovePinningService, name, visitServiceUrl, autoUpload
       </button>
       <ContextMenu className="pv2 ph1" style={{ zIndex: 1001 }} visible={isContextVisible}
         target={buttonRef} onDismiss={() => setContextVisibility(false)} arrowAlign="right">
-        <ContextMenuItem className='pv2 ph1' onClick={ () => onToggleModalOpen(name) }>
-          <StrokeCloud width="28" className='fill-aqua'/> <span className="ph1">{autoUpload ? t('pinningServices.removeAutoUpload') : t('pinningServices.addAutoUpload')}</span>
-        </ContextMenuItem>
+        { showAutoUpload && (
+          <ContextMenuItem className='pv2 ph1' onClick={ () => onToggleModalOpen(name) }>
+            <StrokeCloud width="28" className='fill-aqua'/> <span className="ph1">{autoUpload ? t('pinningServices.removeAutoUpload') : t('pinningServices.addAutoUpload')}</span>
+          </ContextMenuItem>)
+        }
         { visitServiceUrl && (
           <a className='link flex items-center' href={visitServiceUrl} target='_blank' rel='noopener noreferrer'>
             <ContextMenuItem className='pv2 ph1' onClick={ () => setContextVisibility(false) }>


### PR DESCRIPTION
This is a temporary workaround that maintains most of the functionality while being compatible with `pin remote` and `config` commands in go-ipfs 0.8.0:

- when service is added via webui, we replace `.` with `_` so the issue (#1770) never surfaces
- if service with `.` in name was already added or is added via CLI, we disable button for enabling auto upload of MFS, because it is not possible to make it work in go-ipfs 0.8.0, but everything else works as expected (manual pinning to "nft.storage" works fine)

Closes  #1770 (but we will have a separate fix in go-ipfs to support `.` in key names)

@alanshaw just for completeness, would it be ok for you to change `nft.storage` to `nft-storage` on https://nft.storage docs about `pin remote service add`? 