### PR TITLE
fix: cleanup size and bandwidth units

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16308,9 +16308,9 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "filesize": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
-      "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg=="
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.3.0.tgz",
+      "integrity": "sha512-ytx0ruGpDHKWVoiui6+BY/QMNngtDQ/pJaFwfBpQif0J63+E8DLdFyqS3NkKQn7vIruUEpoGD9JUJSg7Kp+I0g=="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -16834,28 +16834,28 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "dev": true,
           "optional": true,
@@ -16866,14 +16866,14 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
           "optional": true,
@@ -16884,42 +16884,42 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "dev": true,
           "optional": true,
@@ -16929,28 +16929,28 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "dev": true,
           "optional": true,
@@ -16960,14 +16960,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
@@ -16984,7 +16984,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "dev": true,
           "optional": true,
@@ -16999,14 +16999,14 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "dev": true,
           "optional": true,
@@ -17016,7 +17016,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "dev": true,
           "optional": true,
@@ -17026,7 +17026,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "optional": true,
@@ -17037,21 +17037,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "optional": true,
@@ -17061,14 +17061,14 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "optional": true,
@@ -17078,14 +17078,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "dev": true,
           "optional": true,
@@ -17096,7 +17096,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "dev": true,
           "optional": true,
@@ -17106,7 +17106,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "optional": true,
@@ -17116,14 +17116,14 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-CaLXV3W8Vnbps8ZANqDGz7j4x7Yj1LW4TWF/TQuDfj7Cfx4nAPTvw98qgTevtto1oHDrh3pQkaODbqupXlsWTg==",
           "dev": true,
           "optional": true,
@@ -17135,7 +17135,7 @@
         },
         "node-pre-gyp": {
           "version": "0.13.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Md1D3xnEne8b/HGVQkZZwV27WUi1ZRuZBij24TNaZwUPU3ZAFtvT6xxJGaUVillfmMKnn5oD1HoGsp2Ftik7SQ==",
           "dev": true,
           "optional": true,
@@ -17154,7 +17154,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
@@ -17165,14 +17165,14 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "dev": true,
           "optional": true,
@@ -17183,7 +17183,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "dev": true,
           "optional": true,
@@ -17196,21 +17196,21 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "optional": true,
@@ -17220,21 +17220,21 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "dev": true,
           "optional": true,
@@ -17245,21 +17245,21 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "dev": true,
           "optional": true,
@@ -17272,7 +17272,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": false,
+              "resolved": "",
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
@@ -17281,7 +17281,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "optional": true,
@@ -17297,7 +17297,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "optional": true,
@@ -17307,49 +17307,49 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "optional": true,
@@ -17361,7 +17361,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "dev": true,
           "optional": true,
@@ -17371,7 +17371,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -17381,14 +17381,14 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "dev": true,
           "optional": true,
@@ -17404,14 +17404,14 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "dev": true,
           "optional": true,
@@ -17421,14 +17421,14 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
           "dev": true,
           "optional": true
@@ -33785,6 +33785,11 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
           "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+        },
+        "filesize": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/filesize/-/filesize-6.1.0.tgz",
+          "integrity": "sha512-LpCHtPQ3sFx67z+uh2HnSyWSLLu5Jxo21795uRDuar/EOuYWXib5EmPaGIBuSnRqH2IODiKA2k5re/K9OnN/Yg=="
         },
         "find-up": {
           "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "details-polyfill": "^1.1.0",
     "eslint-plugin-jsx-a11y": "^6.3.1",
     "file-extension": "^4.0.5",
-    "filesize": "^6.1.0",
+    "filesize": "^6.3.0",
     "hashlru": "^2.3.0",
     "i18next": "^20.1.0",
     "i18next-browser-languagedetector": "^6.1.0",

--- a/src/components/pinning-manager/PinningManager.js
+++ b/src/components/pinning-manager/PinningManager.js
@@ -1,6 +1,5 @@
 import React, { Fragment, useEffect, useState, useMemo, useRef } from 'react'
 import { connect } from 'redux-bundler-react'
-// import filesize from 'filesize'
 import { AutoSizer, Table, Column, SortDirection } from 'react-virtualized'
 import { sortByProperty } from '../../lib/sort'
 
@@ -137,8 +136,8 @@ const ServiceCell = ({ rowData, rowIndex }) => (
 // const SizeCell = ({ rowData, t }) => (
 //   <p className={ !rowData.totalSize ? 'gray nowrap' : 'nowrap'}>{ !rowData.totalSize
 //     ? `${(t('app:terms:loading'))}...`
-//     : filesize(rowData.totalSize || 0, {
-//       round: rowData.totalSize >= 1000000000 ? 1 : 0, spacer: ''
+//     : humanSize(rowData.totalSize || 0, {
+//       round: rowData.totalSize >= 1073741824 ? 1 : 0, spacer: ''
 //     })}</p>
 // )
 const NumberOfPinsCell = ({ rowData, t }) => {

--- a/src/files/file-import-status/FileImportStatus.js
+++ b/src/files/file-import-status/FileImportStatus.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState, useCallback } from 'react'
-import filesize from 'filesize'
+import { humanSize } from '../../lib/files'
 import PropTypes from 'prop-types'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
@@ -20,7 +20,7 @@ const Import = (job, t) =>
       <span className="fileImportStatusName truncate">{item.path}</span>
       <span className='gray mh2'> |
         { item.entries && (<span> { t('filesImportStatus.count', { count: item.entries.length }) } | </span>) }
-        <span className='ml2'>{ filesize(item.size) }</span>
+        <span className='ml2'>{ humanSize(item.size) }</span>
       </span>
       {viewImportStatus(job, item.progress)}
     </li>

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -1,10 +1,9 @@
 import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
 import { join, basename } from 'path'
-import filesize from 'filesize'
 import { withTranslation } from 'react-i18next'
 import classnames from 'classnames'
-import { normalizeFiles } from '../../lib/files'
+import { normalizeFiles, humanSize } from '../../lib/files'
 // React DnD
 import { useDrag, useDrop } from 'react-dnd'
 // Components
@@ -96,7 +95,7 @@ const File = ({
     styles.borderTop = '1px solid #eee'
   }
 
-  size = size ? filesize(size, { round: 0 }) : '-'
+  size = size ? humanSize(size, { round: 0 }) : '-'
   const hash = cid.toString() || t('hashUnavailable')
 
   const select = (select) => onSelect(name, select)

--- a/src/files/header/Header.js
+++ b/src/files/header/Header.js
@@ -1,8 +1,8 @@
 import React from 'react'
-import filesize from 'filesize'
 import classNames from 'classnames'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
+import { humanSize } from '../../lib/files'
 // Components
 import Breadcrumbs from '../breadcrumbs/Breadcrumbs'
 import FileInput from '../file-input/FileInput'
@@ -17,13 +17,11 @@ const BarOption = ({ children, text, isLink = false, className = '', ...etc }) =
   </div>
 )
 
-function humanSize (size) {
-  if (!size) return 'N/A'
-
-  return filesize(size || 0, {
-    round: size >= 1000000000 ? 1 : 0, spacer: ''
-  })
-}
+// Tweak human-readable size format to be more compact
+const size = (s) => humanSize(s, {
+  round: s >= 1073741824 ? 1 : 0, // show decimal > 1GiB
+  spacer: ''
+})
 
 class Header extends React.Component {
   handleContextMenu = (ev) => {
@@ -65,14 +63,14 @@ class Header extends React.Component {
             { hasUpperDirectory
               ? (
                 <span>
-                  { humanSize(currentDirectorySize) }<span className='f5 gray'>/{ humanSize(filesSize) }</span>
+                  { size(currentDirectorySize) }<span className='f5 gray'>/{ size(filesSize) }</span>
                 </span>
               )
-              : humanSize(filesSize) }
+              : size(filesSize) }
           </BarOption>
 
           <BarOption title={t('allBlocksDescription')} text={t('allBlocks')}>
-            { humanSize(repoSize) }
+            { size(repoSize) }
           </BarOption>
 
           <div className='pa3'>

--- a/src/files/modals/pinning-modal/PinningModal.js
+++ b/src/files/modals/pinning-modal/PinningModal.js
@@ -1,21 +1,13 @@
 import React, { useEffect, useMemo, useState } from 'react'
 import PropTypes from 'prop-types'
 import { /* Trans, */ withTranslation } from 'react-i18next'
-import filesize from 'filesize'
+import { humanSize } from '../../../lib/files'
 import Button from '../../../components/button/Button'
 import Checkbox from '../../../components/checkbox/Checkbox'
 import GlyphPin from '../../../icons/GlyphPin'
 import { Modal, ModalActions, ModalBody } from '../../../components/modal/Modal'
 import { connect } from 'redux-bundler-react'
 import './PinningModal.css'
-
-const humanSize = (size) => {
-  if (!size) return 'N/A'
-
-  return filesize(size || 0, {
-    round: size >= 1000000000 ? 1 : 0, spacer: ''
-  })
-}
 
 const PinIcon = ({ icon, index }) => {
   if (icon) {

--- a/src/files/selected-actions/SelectedActions.js
+++ b/src/files/selected-actions/SelectedActions.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
-import filesize from 'filesize'
+import { humanSize } from '../../lib/files'
 import { withTranslation } from 'react-i18next'
 import StrokePin from '../../icons/StrokePin'
 import GlyphSmallCancel from '../../icons/GlyphSmallCancel'
@@ -120,7 +120,7 @@ class SelectedActions extends React.Component {
               </div>
               <div className='dn db-l f6'>
                 <p className='ma0'>{t('filesSelected', { count })}</p>
-                <p className='ma0 mt1' style={styles.size}>{t('totalSize', { size: filesize(size) })}</p>
+                <p className='ma0 mt1' style={styles.size}>{t('totalSize', { size: humanSize(size) })}</p>
               </div>
             </div>
           </div>

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -1,3 +1,4 @@
+import filesize from 'filesize'
 /**
  * @typedef {import('ipfs').IPFSService} IPFSService
  * @typedef {import('../bundles/files/actions').FileStat} FileStat
@@ -137,4 +138,21 @@ export async function getShareableLink (files, ipfs) {
   }
 
   return `https://ipfs.io/ipfs/${cid}${filename || ''}`
+}
+
+/**
+ * @param {number} size in bytes
+ * @returns {string} human-readable size
+ */
+export function humanSize (size, opts) {
+  if (typeof size === 'undefined') return 'N/A'
+  return filesize(size || 0, {
+    // base-2 byte units (GiB, MiB, KiB) to remove any ambiguity
+    spacer: String.fromCharCode(160), // non-breakable space (&nbsp)
+    round: size >= 1073741824 ? 1 : 0, // show decimal > 1GiB
+    standard: 'iec',
+    base: 2,
+    bits: false,
+    ...opts
+  })
 }

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -142,6 +142,7 @@ export async function getShareableLink (files, ipfs) {
 
 /**
  * @param {number} size in bytes
+ * @param {object} opts format customization
  * @returns {string} human-readable size
  */
 export function humanSize (size, opts) {

--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -7,8 +7,16 @@ import PropTypes from 'prop-types'
 import filesize from 'filesize'
 import { Title } from './Commons'
 
-const chartsize = filesize.partial({ round: 1, exponent: 2, bits: true })
-const tootltipSize = filesize.partial({ round: 0, bits: true, output: 'array' })
+// network bandwidth units in base-10 bits (Mbps)
+// to align with what ISP usually shows on invoice
+const humanUnits = {
+  standard: 'jedec',
+  base: 10,
+  bits: true
+}
+
+const chartsize = filesize.partial({ round: 1, exponent: 2, ...humanUnits })
+const tootltipSize = filesize.partial({ round: 0, output: 'array', ...humanUnits })
 
 const defaultSettings = {
   defaultFontFamily: "'Inter UI', system-ui, sans-serif",
@@ -29,7 +37,7 @@ const defaultSettings = {
     yAxes: [{
       stacked: true,
       ticks: {
-        callback: v => chartsize(v) + '/s',
+        callback: v => chartsize(v) + 'ps',
         suggestedMax: 200000,
         maxTicksLimit: 5
       }
@@ -65,12 +73,12 @@ const Tooltip = ({ t, bw, show, pos }) => {
         <div className='dt-row'>
           <span className='dtc f7 charcoal tr'>{t('app:terms.in').toLowerCase()}:</span>
           <span className='f4 ml1 charcoal-muted'>{bw.in[0]}</span>
-          <span className='f7 charcoal-muted'>{bw.in[1]}/s</span>
+          <span className='f7 charcoal-muted'>{bw.in[1]}ps</span>
         </div>
         <div className='dt-row'>
           <span className='dtc f7 charcoal tr'>{t('app:terms.out').toLowerCase()}:</span>
           <span className='f4 ml1 charcoal-muted'>{bw.out[0]}</span>
-          <span className='f7 charcoal-muted'>{bw.out[1]}/s</span>
+          <span className='f7 charcoal-muted'>{bw.out[1]}ps</span>
         </div>
       </div>
     </div>

--- a/src/status/PeerBandwidthTable.js
+++ b/src/status/PeerBandwidthTable.js
@@ -2,14 +2,14 @@ import React, { Component } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import PropTypes from 'prop-types'
-import filesize from 'filesize'
+import { humanSize } from '../lib/files'
 import CountryFlag from 'react-country-flag'
 import Box from '../components/box/Box'
 import { Title } from './Commons'
 import ComponentLoader from '../loader/ComponentLoader.js'
 
 const isWindows = window.navigator.appVersion.indexOf('Win') !== -1
-const humansize = filesize.partial({ round: 0 })
+const humansize = s => humanSize(s, { round: 0 })
 
 export class PeerBandwidthTable extends Component {
   static propTypes = {

--- a/src/status/Speedometer.js
+++ b/src/status/Speedometer.js
@@ -30,7 +30,11 @@ function Speedometer ({ total = 100, title, filled = 0, noSpeed = false, color =
     }
   }
 
+  // network bandwidth units in base-10 bits (Mbps)
+  // to align with what ISP usually shows on invoice
   const data = filesize(filled, {
+    standard: 'jedec',
+    base: 10,
     output: 'array',
     round: 0,
     bits: !noSpeed
@@ -43,7 +47,7 @@ function Speedometer ({ total = 100, title, filled = 0, noSpeed = false, color =
       </div>
 
       <div className='absolute' style={{ top: '60%', left: '50%', transform: 'translate(-50%, -50%)' }} >
-        <span className='f3'>{data[0]}</span><span className='ml1 f7'>{data[1]}{ noSpeed ? '' : '/s' }</span>
+        <span className='f3'>{data[0]}</span><span className='ml1 f7'>{data[1]}{ noSpeed ? '' : 'ps' }</span>
         <span className='db f7 fw5'>{title}</span>
       </div>
     </div>

--- a/src/status/StatusConnected.js
+++ b/src/status/StatusConnected.js
@@ -1,10 +1,10 @@
 import React from 'react'
 import { withTranslation, Trans } from 'react-i18next'
 import { connect } from 'redux-bundler-react'
-import filesize from 'filesize'
+import { humanSize } from '../lib/files'
 
 export const StatusConnected = ({ t, peersCount, repoSize }) => {
-  const humanRepoSize = filesize(repoSize || 0, { round: 1 })
+  const humanRepoSize = humanSize(repoSize || 0)
   return (
     <header>
       <h1 className='montserrat fw2 f3 charcoal ma0 pt0 pb2'>

--- a/test/e2e/files.test.js
+++ b/test/e2e/files.test.js
@@ -47,9 +47,13 @@ describe('Files screen', () => {
     await expect(page).toMatch(result1.cid.toString())
     await expect(page).toMatch(result2.cid.toString())
 
-    // expect human readable sizes
+    // expect human readable sizes in format from ./src/lib/files.js#humanSize
     // → this ensures metadata was correctly read for each item in the MFS
-    const human = (b) => (b ? filesize(b, { round: 0 }) : '-')
+    const human = (b) => (b ? filesize(b, {
+      standard: 'iec',
+      base: 2,
+      round: b >= 1073741824 ? 1 : 0
+    }) : '-')
     for await (const file of ipfs.files.ls('/')) {
       await expect(page).toMatch(human(file.size))
     }


### PR DESCRIPTION
This cleans up code around human-readable units and Closes #1778:

- base-2 (GiB, MiB, KiB) used for file sizes to remove any unit confusion while keeping interop with 1024  way of thinking 
  > ![2021-05-20--00-34-50](https://user-images.githubusercontent.com/157609/118893775-4ba3d280-b903-11eb-8b59-a34ffd609834.png)

- base-10 (Mbps, kbps) used for network bandwith, to match what the number that ISP is selling:
  > ![2021-05-20--00-14-20](https://user-images.githubusercontent.com/157609/118893056-1e0a5980-b902-11eb-931d-06018f5e8247.png)


@jessicaschilling  @olizilla would appreciate sanity check from your end. What units are expected by people these days? I've heard that macOS switched sizes in Finder to base-10, is that true? 

