### PR TITLE
style: Secret Access Token label

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -38,7 +38,7 @@
     "nicknamePlaceholder": "Name for your service",
     "apiEndpoint": "API endpoint",
     "apiEndpointPlaceholder": "URL for its API endpoint",
-    "secretApiKey": "Secret API key",
+    "secretApiKey": "Secret Access Token",
     "autoUpload": "Auto upload"
   },
   "autoUploadModal": {
@@ -49,7 +49,7 @@
     "nickname": "Nickname is required",
     "apiError": "API error",
     "apiEndpoint": "Must be a valid URL",
-    "secretApiKey": "Secret key is required",
+    "secretApiKey": "Secret Access Token is required",
     "failedToFetch": "Failed to fetch",
     "failedToFetchTitle": "Unable to fetch pin count from this remote service. Make sure it is online and that you entered correct credentials. If this is a newly added service, try removing and adding it again."
   },

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -38,7 +38,7 @@
     "nicknamePlaceholder": "Name for your service",
     "apiEndpoint": "API endpoint",
     "apiEndpointPlaceholder": "URL for its API endpoint",
-    "secretApiKey": "Secret Access Token",
+    "secretApiKey": "Secret access token",
     "autoUpload": "Auto upload"
   },
   "autoUploadModal": {
@@ -49,7 +49,7 @@
     "nickname": "Nickname is required",
     "apiError": "API error",
     "apiEndpoint": "Must be a valid URL",
-    "secretApiKey": "Secret Access Token is required",
+    "secretApiKey": "Secret access token is required",
     "failedToFetch": "Failed to fetch",
     "failedToFetchTitle": "Unable to fetch pin count from this remote service. Make sure it is online and that you entered correct credentials. If this is a newly added service, try removing and adding it again."
   },


### PR DESCRIPTION
This PR renames "Secret API key" to "Secret access token" to align better with terminology uses in https://ipfs.github.io/pinning-services-api-spec/ and reduce confusion described in https://github.com/ipfs/ipfs-webui/issues/1786#issuecomment-841577866.

>  ![2021-05-20--18-57-08](https://user-images.githubusercontent.com/157609/119019208-3c716300-b99d-11eb-8d34-4557787d942c.png)


Closes #1786

@obo20 @ipfs/wg-pinning-services any concerns?