### PR TITLE
fix: allow spaces in rename modal

### DIFF
--- a/src/components/text-input-modal/TextInputModal.js
+++ b/src/components/text-input-modal/TextInputModal.js
@@ -34,7 +34,7 @@ class TextInputModal extends React.Component {
   }
 
   onChange = (event) => {
-    let val = event.target.value.trim()
+    let val = event.target.value
 
     if (this.props.onChange) {
       val = this.props.onChange(val)

--- a/src/files/modals/add-by-path-modal/AddByPathModal.js
+++ b/src/files/modals/add-by-path-modal/AddByPathModal.js
@@ -28,7 +28,7 @@ function ByPathModal ({ t, tReady, onCancel, onSubmit, className, ...props }) {
 
   return (
     <TextInputModal
-      validate={(p) => validatePath(p)}
+      validate={(p) => validatePath(p.trim())}
       onSubmit={(p) => onSubmit(p.trim())}
       onChange={(p) => p.trimStart()}
       onCancel={onCancel}


### PR DESCRIPTION
Closes #1775 my moving fix from #1718 to be applies only to "import from ipfs" modal.