### PR TITLE
remove ensureMFS call when generating share link

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -418,7 +418,6 @@ const actions = () => ({
    */
   doFilesShareLink: (files) => perform(ACTIONS.SHARE_LINK, async (ipfs) => {
     // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
-    
     return await getShareableLink(files, ipfs)
   }),
 

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -416,9 +416,9 @@ const actions = () => ({
    * Generates sharable link for the provided files.
    * @param {FileStat[]} files
    */
-  doFilesShareLink: (files) => perform(ACTIONS.SHARE_LINK, async (ipfs, { store }) => {
-    ensureMFS(store)
-
+  doFilesShareLink: (files) => perform(ACTIONS.SHARE_LINK, async (ipfs) => {
+    // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
+    
     return await getShareableLink(files, ipfs)
   }),
 


### PR DESCRIPTION
This removes the call to `ensureMFS` in `doFilesShareLink` to fix and close https://github.com/ipfs/ipfs-webui/issues/1744

I wasn't able to run the e2e tests on my machine, so we'll see if anything complains in CI, I guess :)

cc @lidel 