### PR TITLE
fix: move output below input to be less confusing

### DIFF
--- a/src/bundles/node-bandwidth-chart.js
+++ b/src/bundles/node-bandwidth-chart.js
@@ -22,7 +22,7 @@ function createNodeBandwidthChart (opts) {
     doUpdateNodeBandwidthChartData: (bw, timestamp, chartData) => ({ dispatch }) => {
       chartData = {
         in: chartData.in.concat({ x: timestamp, y: parseInt(bw.rateIn.toFixed(0), 10) }),
-        out: chartData.out.concat({ x: timestamp, y: parseInt(bw.rateOut.toFixed(0), 10) })
+        out: chartData.out.concat({ x: timestamp, y: parseInt(bw.rateOut.toFixed(0) * -1, 10) })
       }
 
       const startIndex = chartData.in.findIndex(d => d.x >= timestamp - opts.windowSize)

--- a/src/status/NetworkTraffic.js
+++ b/src/status/NetworkTraffic.js
@@ -46,15 +46,15 @@ class NetworkTraffic extends React.Component {
         <div className='flex flex-column justify-between' style={{ maxWidth: 400 }}>
           <div className='mh2 mv3 mt0-l'>
             <Speedometer
-              title={t('app:terms.upSpeed')}
-              color='#f39021'
-              {...upSpeed} />
-          </div>
-          <div className='mh2 mt3 mt0-l'>
-            <Speedometer
               title={t('app:terms.downSpeed')}
               color='#69c4cd'
               {...downSpeed} />
+          </div>
+          <div className='mh2 mt3 mt0-l'>
+            <Speedometer
+              title={t('app:terms.upSpeed')}
+              color='#f39021'
+              {...upSpeed} />
           </div>
         </div>
       </div>

--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -7,16 +7,14 @@ import PropTypes from 'prop-types'
 import filesize from 'filesize'
 import { Title } from './Commons'
 
-// network bandwidth units in base-10 bits (Mbps)
-// to align with what ISP usually shows on invoice
-const humanUnits = {
-  standard: 'jedec',
-  base: 10,
-  bits: true
+// matching units returned by 'ipfs stats bw' in CLI
+const bwUnits = {
+  standard: 'iec',
+  base: 2
 }
 
-const chartsize = filesize.partial({ round: 1, exponent: 2, ...humanUnits })
-const tootltipSize = filesize.partial({ round: 0, output: 'array', ...humanUnits })
+const chartsize = filesize.partial({ round: 1, exponent: 2, ...bwUnits })
+const tootltipSize = filesize.partial({ round: 0, output: 'array', ...bwUnits })
 
 const defaultSettings = {
   defaultFontFamily: "'Inter UI', system-ui, sans-serif",
@@ -37,7 +35,7 @@ const defaultSettings = {
     yAxes: [{
       stacked: true,
       ticks: {
-        callback: v => chartsize(v) + 'ps',
+        callback: v => chartsize(v) + '/s',
         suggestedMax: 200000,
         maxTicksLimit: 5
       }
@@ -73,12 +71,12 @@ const Tooltip = ({ t, bw, show, pos }) => {
         <div className='dt-row'>
           <span className='dtc f7 charcoal tr'>{t('app:terms.in').toLowerCase()}:</span>
           <span className='f4 ml1 charcoal-muted'>{bw.in[0]}</span>
-          <span className='f7 charcoal-muted'>{bw.in[1]}ps</span>
+          <span className='f7 charcoal-muted'>{bw.in[1]}/s</span>
         </div>
         <div className='dt-row'>
           <span className='dtc f7 charcoal tr'>{t('app:terms.out').toLowerCase()}:</span>
           <span className='f4 ml1 charcoal-muted'>{bw.out[0]}</span>
-          <span className='f7 charcoal-muted'>{bw.out[1]}ps</span>
+          <span className='f7 charcoal-muted'>{bw.out[1]}/s</span>
         </div>
       </div>
     </div>

--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -128,18 +128,18 @@ class NodeBandwidthChart extends React.Component {
       return {
         datasets: [
           {
-            label: t('app:terms.in'),
-            data: nodeBandwidthChartData.in,
-            borderColor: gradientIn,
-            backgroundColor: gradientIn,
-            pointRadius: 2,
-            cubicInterpolationMode: 'monotone'
-          },
-          {
             label: t('app:terms.out'),
             data: nodeBandwidthChartData.out,
             borderColor: gradientOut,
             backgroundColor: gradientOut,
+            pointRadius: 2,
+            cubicInterpolationMode: 'monotone'
+          },
+          {
+            label: t('app:terms.in'),
+            data: nodeBandwidthChartData.in,
+            borderColor: gradientIn,
+            backgroundColor: gradientIn,
             pointRadius: 2,
             cubicInterpolationMode: 'monotone'
           }

--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -10,7 +10,8 @@ import { Title } from './Commons'
 // matching units returned by 'ipfs stats bw' in CLI
 const bwUnits = {
   standard: 'iec',
-  base: 2
+  base: 2,
+  bits: false
 }
 
 const chartsize = filesize.partial({ round: 1, exponent: 2, ...bwUnits })

--- a/src/status/NodeBandwidthChart.js
+++ b/src/status/NodeBandwidthChart.js
@@ -42,6 +42,7 @@ const defaultSettings = {
     }]
   },
   legend: {
+    reverse: true,
     display: true,
     position: 'bottom'
   }
@@ -177,8 +178,8 @@ class NodeBandwidthChart extends React.Component {
             data.show = false
           } else {
             data.bw = {
-              in: tootltipSize(model.dataPoints[0].yLabel),
-              out: tootltipSize(model.dataPoints[1].yLabel)
+              out: tootltipSize(Math.abs(model.dataPoints[0].yLabel)),
+              in: tootltipSize(Math.abs(model.dataPoints[1].yLabel))
             }
 
             const rect = this._chart.canvas.getBoundingClientRect()

--- a/src/status/Speedometer.js
+++ b/src/status/Speedometer.js
@@ -37,7 +37,7 @@ function Speedometer ({ total = 100, title, filled = 0, noSpeed = false, color =
     base: 2,
     output: 'array',
     round: 0,
-    bits: !noSpeed
+    bits: false
   })
 
   return (

--- a/src/status/Speedometer.js
+++ b/src/status/Speedometer.js
@@ -30,11 +30,11 @@ function Speedometer ({ total = 100, title, filled = 0, noSpeed = false, color =
     }
   }
 
-  // network bandwidth units in base-10 bits (Mbps)
+  // network bandwidth units matchin 'ipfs stats bw'
   // to align with what ISP usually shows on invoice
   const data = filesize(filled, {
-    standard: 'jedec',
-    base: 10,
+    standard: 'iec',
+    base: 2,
     output: 'array',
     round: 0,
     bits: !noSpeed
@@ -47,7 +47,7 @@ function Speedometer ({ total = 100, title, filled = 0, noSpeed = false, color =
       </div>
 
       <div className='absolute' style={{ top: '60%', left: '50%', transform: 'translate(-50%, -50%)' }} >
-        <span className='f3'>{data[0]}</span><span className='ml1 f7'>{data[1]}{ noSpeed ? '' : 'ps' }</span>
+        <span className='f3'>{data[0]}</span><span className='ml1 f7'>{data[1]}{ noSpeed ? '' : '/s' }</span>
         <span className='db f7 fw5'>{title}</span>
       </div>
     </div>


### PR DESCRIPTION
...in some scenarios. it's a stacked graph, so the total height is in+out, when out is tiny and in is large it is not obvious that out is a tiny sliver stacked on top.

<img width="1244" alt="Screenshot 2021-06-18 at 15 05 06" src="https://user-images.githubusercontent.com/58871/122582061-9e31f500-d04f-11eb-8915-992ce60e5eb4.png">

fixes #1797
License: MIT
Signed-off-by: Oli Evans <oli@tableflip.io>