### PR TITLE
feat: link to pinning service docs if available

### DIFF
--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -39,7 +39,7 @@
     "apiEndpoint": "API endpoint",
     "apiEndpointPlaceholder": "URL for its API endpoint",
     "secretApiKey": "Secret access token",
-    "secretApiKeyHowToLink": "How to generate a new token?",
+    "secretApiKeyHowToLink": "How to generate a new token",
     "autoUpload": "Auto upload"
   },
   "autoUploadModal": {

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -39,6 +39,7 @@
     "apiEndpoint": "API endpoint",
     "apiEndpointPlaceholder": "URL for its API endpoint",
     "secretApiKey": "Secret access token",
+    "secretApiKeyHowToLink": "How to generate a new token?",
     "autoUpload": "Auto upload"
   },
   "autoUploadModal": {

--- a/src/components/pinning-manager/pinning-manager-modal/PinningManagerModal.js
+++ b/src/components/pinning-manager/pinning-manager-modal/PinningManagerModal.js
@@ -46,7 +46,7 @@ const PinningManagerModal = ({ t, tReady, onLeave, className, remoteServiceTempl
       </ModalActions>
 
       <Overlay show={!!selectedService} onLeave={onModalClose} hidden>
-        <PinningServiceModal className='outline-0' service={selectedService} onSuccess={onSuccess} onLeave={onModalClose} nickname={selectedServiceInfo.nickname} apiEndpoint={selectedServiceInfo.apiEndpoint} t={t} />
+        <PinningServiceModal className='outline-0' service={selectedService} onSuccess={onSuccess} onLeave={onModalClose} nickname={selectedServiceInfo.nickname} apiEndpoint={selectedServiceInfo.apiEndpoint} visitServiceUrl={selectedServiceInfo.visitServiceUrl} t={t} />
       </Overlay>
     </Modal>
   )

--- a/src/components/pinning-manager/pinning-manager-service-modal/PinningManagerServiceModal.js
+++ b/src/components/pinning-manager/pinning-manager-service-modal/PinningManagerServiceModal.js
@@ -10,7 +10,7 @@ import { Modal, ModalBody, ModalActions } from '../../modal/Modal'
 import Button from '../../button/Button'
 import './PinningManagerServiceModal.css'
 
-const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service, tReady, doAddPinningService, nickname, apiEndpoint, secretApiKey, ...props }) => {
+const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service, tReady, doAddPinningService, nickname, apiEndpoint, visitServiceUrl, secretApiKey, ...props }) => {
   const { register, errors, clearErrors, setError, handleSubmit } = useForm({
     defaultValues: {
       nickname,
@@ -82,6 +82,9 @@ const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service,
 
             <label htmlFor="cm-secretApiKey">
               { t('pinningServiceModal.secretApiKey') }
+              { service.icon && service.name && visitServiceUrl && (
+                <a className='f7 link pv0 lh-copy dib' href={ visitServiceUrl } rel='noopener noreferrer' target="_blank"> { t('pinningServiceModal.secretApiKeyHowToLink') }</a>
+              )}
             </label>
             <div className='relative'>
               <input id='cm-secretApiKey'
@@ -101,7 +104,7 @@ const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service,
           <p className='f6'>
             <Trans i18nKey="pinningServiceModal.description" t={t}>
               Want to make your custom pinning service available to others?
-              <a href='https://docs.ipfs.io/how-to/work-with-pinning-services/' rel='noopener noreferrer' target="_blank" className='pv0' type='link'>Learn how.</a>
+              <a href='https://docs.ipfs.io/how-to/work-with-pinning-services/' rel='noopener noreferrer' target="_blank" className='pv0 dib link' type='link'>Learn how.</a>
             </Trans>
           </p>
         </ModalBody>


### PR DESCRIPTION
This PR adds a link to docs next to "Secret access token", making it easier for users of predefined services like Pinata to learn how to generate a new token. 

The link to docs is defined in https://github.com/ipfs/ipfs-webui/blob/dadaf04219f2cc38118ddcde48f4b42fb1de2643/src/constants/pinning.js#L9

>  ![2021-06-24--23-52-20](https://user-images.githubusercontent.com/157609/123337588-bae69500-d547-11eb-8eda-155793ff3bbb.png)

