### PR TITLE
Try to get a custom shareble link.

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -423,9 +423,9 @@ const actions = () => ({
    * Generates sharable link for the provided files.
    * @param {FileStat[]} files
    */
-  doFilesShareLink: (files) => perform(ACTIONS.SHARE_LINK, async (ipfs) => {
+  doFilesShareLink: (files) => perform(ACTIONS.SHARE_LINK, async (ipfs, { store }) => {
     // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
-    return await getShareableLink(files, ipfs)
+    return await getShareableLink(files, store.selectGatewayUrl(), ipfs)
   }),
 
   /**

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -121,10 +121,11 @@ export async function getDownloadLink (files, gatewayUrl, apiUrl, ipfs) {
 
 /**
  * @param {FileStat[]} files
+ * @param {string} gatewayUrl
  * @param {IPFSService} ipfs
  * @returns {Promise<string>}
  */
-export async function getShareableLink (files, ipfs) {
+export async function getShareableLink (files, gatewayUrl, ipfs) {
   let cid
   let filename
 
@@ -137,7 +138,7 @@ export async function getShareableLink (files, ipfs) {
     cid = await makeCIDFromFiles(files, ipfs)
   }
 
-  return `https://ipfs.io/ipfs/${cid}${filename || ''}`
+  return `${gatewayUrl}/ipfs/${cid}${filename || ''}`
 }
 
 /**


### PR DESCRIPTION
Is there a way to get a custom shareable link but omitting ensureMFS function?

replace ipfs.io to 

```
return `${gatewayUrl}/ipfs/${cid}${filename || ''}`
```