### PR TITLE
fix: download directories outside of MFS

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -412,8 +412,6 @@ const actions = () => ({
    * @param {FileStat[]} files
    */
   doFilesDownloadLink: (files) => perform(ACTIONS.DOWNLOAD_LINK, async (ipfs, { store }) => {
-    ensureMFS(store)
-
     const apiUrl = store.selectApiUrl()
     const gatewayUrl = store.selectGatewayUrl()
     return await getDownloadLink(files, gatewayUrl, apiUrl, ipfs)

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -46,11 +46,12 @@ export function normalizeFiles (files) {
  * @returns {Promise<FileDownload>}
  */
 async function downloadSingle (file, gatewayUrl, apiUrl) {
-  let url, filename, method
+  let url, filename, name, method
 
   if (file.type === 'directory') {
     url = `${apiUrl}/api/v0/get?arg=${file.cid}&archive=true&compress=true`
-    filename = `${file.name}.tar.gz`
+    name = file.name || `download_${file.cid}` // Name is not always available.
+    filename = `${name}.tar.gz`
     method = 'POST' // API is POST-only
   } else {
     url = `${gatewayUrl}/ipfs/${file.cid}`

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -46,11 +46,11 @@ export function normalizeFiles (files) {
  * @returns {Promise<FileDownload>}
  */
 async function downloadSingle (file, gatewayUrl, apiUrl) {
-  let url, filename, name, method
+  let url, filename, method
 
   if (file.type === 'directory') {
+    const name = file.name || `download_${file.cid}` // Name is not always available.
     url = `${apiUrl}/api/v0/get?arg=${file.cid}&archive=true&compress=true`
-    name = file.name || `download_${file.cid}` // Name is not always available.
     filename = `${name}.tar.gz`
     method = 'POST' // API is POST-only
   } else {


### PR DESCRIPTION
Fixes #1829.

I went with a simpler approach than https://github.com/ipfs/ipfs-webui/issues/1814#issuecomment-873000366 (suggested fix) because the API is POST-only, so creating a link and then "opening" it would have returned a 405 error.

When https://github.com/ipfs/go-ipfs/issues/8234 is merged, #1814 can be addressed. In the meanwhile, #1829 is easily fixed.

The failing tests are the same as in the main branch.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>