### PR TITLE
fix: do not show api address form on Desktop

### DIFF
--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -27,7 +27,7 @@ import { cliCmdKeys, cliCommandList } from '../bundles/files/consts'
 const PAUSE_AFTER_SAVE_MS = 3000
 
 export const SettingsPage = ({
-  t, tReady, isIpfsConnected, ipfsPendingFirstConnection,
+  t, tReady, isIpfsConnected, ipfsPendingFirstConnection, isIpfsDesktop,
   isConfigBlocked, isLoading, isSaving, arePinningServicesSupported,
   hasSaveFailed, hasSaveSucceded, hasErrors, hasLocalChanges, hasExternalChanges,
   config, onChange, onReset, onSave, editorKey, analyticsEnabled, doToggleAnalytics,
@@ -48,15 +48,17 @@ export const SettingsPage = ({
       </div>
       : null }
 
-    <Box className='mb3 pa4-l pa2 joyride-settings-customapi'>
-      <div className='lh-copy charcoal'>
-        <Title>{t('app:terms.apiAddress')}</Title>
-        <Trans i18nKey='apiDescription' t={t}>
-          <p>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom API address</a>, including a port other than the default 5001, enter it here.</p>
-        </Trans>
-        <ApiAddressForm/>
-      </div>
-    </Box>
+    { isIpfsDesktop
+      ? null
+      : <Box className='mb3 pa4-l pa2 joyride-settings-customapi'>
+        <div className='lh-copy charcoal'>
+          <Title>{t('app:terms.apiAddress')}</Title>
+          <Trans i18nKey='apiDescription' t={t}>
+            <p>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/go-ipfs/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom API address</a>, including a port other than the default 5001, enter it here.</p>
+          </Trans>
+          <ApiAddressForm/>
+        </div>
+      </Box> }
 
     <Box className='mb3 pa4-l pa2 joyride-settings-pinning'>
       <Title>{t('pinningServices.title')}</Title>


### PR DESCRIPTION
Disable the API address form on IPFS Desktop.

Implements the first TODO from https://github.com/ipfs/ipfs-desktop/issues/1888#issuecomment-898472573

Note: this is needed: https://github.com/ipfs/ipfs-desktop/pull/1894

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>