### PR TITLE
fix: do not load binary content

### DIFF
--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -104,7 +104,6 @@ const PreviewItem = ({ t, name, cid, size, type, availableGatewayUrl: gatewayUrl
       }
 
       if (isBinary(content)) {
-        loadContent()
         return cantPreview
       }
 


### PR DESCRIPTION
Fixes #1819 by stopping to load the content after we determine it is binary.

I'm not completely sure why it works. I tried playing with the `loadContent` function to see if anything was wrong, but couldn't find the culprit.

@rafaelramalho19 I'm assigning you to review to make sure that the removal of that line doesn't have any issues. I'm not sure why we need to call `loadContent` after we determine that it is a binary file.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>