### PR TITLE
fix: update desktop language

### DIFF
--- a/src/bundles/ipfs-desktop.js
+++ b/src/bundles/ipfs-desktop.js
@@ -6,6 +6,7 @@
  * @property {() => Promise<void|Array<{path:string, size:number, content:AsyncIterable<Uint8Array>}>>} selectDirectory
  * @property {(consent:string[]) => void} removeConsent
  * @property {(consent:string[]) => void} addConsent
+ * @property {(language:string) => void} updateLanguage
  */
 // @ts-ignore
 /** @type {{ ipfsDesktop: IPFSDesktop }} */
@@ -57,6 +58,14 @@ const desktopActions = {
    */
   doDesktopRemoveConsent: consent => () => {
     return root.ipfsDesktop.removeConsent(consent)
+  },
+
+  /**
+   * @param {string} language
+   * @returns {() => void}
+   */
+  doDesktopUpdateLanguage: language => () => {
+    return root.ipfsDesktop.updateLanguage(language)
   }
 }
 

--- a/src/components/language-selector/language-modal/LanguageModal.js
+++ b/src/components/language-selector/language-modal/LanguageModal.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'redux-bundler-react'
 import i18n, { localesList } from '../../../i18n'
 
 // Components
@@ -7,9 +8,12 @@ import { Modal, ModalBody, ModalActions } from '../../modal/Modal'
 import SpeakerIcon from '../../../icons/StrokeSpeaker'
 import Button from '../../button/Button'
 
-const LanguageModal = ({ t, tReady, onLeave, link, className, ...props }) => {
+const LanguageModal = ({ t, tReady, onLeave, link, className, isIpfsDesktop, doDesktopUpdateLanguage, ...props }) => {
   const handleClick = (lang) => {
     i18n.changeLanguage(lang)
+    if (isIpfsDesktop) {
+      doDesktopUpdateLanguage(lang)
+    }
     onLeave()
   }
 
@@ -50,4 +54,8 @@ LanguageModal.defaultProps = {
   className: ''
 }
 
-export default LanguageModal
+export default connect(
+  'selectIsIpfsDesktop',
+  'doDesktopUpdateLanguage',
+  LanguageModal
+)


### PR DESCRIPTION
Goes with https://github.com/ipfs/ipfs-desktop/pull/1894.

I think language switching wasn't even working at all because we're not using the localStorage anymore and IPFS Desktop simply had a wrapper around the localStorage.setItem function. Now it's more explicit and does not have room for many mistakes.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>