### PR TITLE
fix: frozen pinning service modal error

### DIFF
--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -10,7 +10,7 @@ const parseService = async (service, remoteServiceTemplates, ipfs) => {
   const parsedService = { ...service, name: service.service, icon, visitServiceUrl, autoUpload }
 
   if (service?.stat?.status === 'invalid') {
-    return { ...parsedService, numberOfPins: 'Error', online: false }
+    return { ...parsedService, numberOfPins: -1, online: false }
   }
 
   const numberOfPins = service.stat?.pinCount?.pinned

--- a/src/components/pinning-manager/PinningManager.js
+++ b/src/components/pinning-manager/PinningManager.js
@@ -141,7 +141,7 @@ const ServiceCell = ({ rowData, rowIndex }) => (
 //     })}</p>
 // )
 const NumberOfPinsCell = ({ rowData, t }) => {
-  if (!serviceOnline(rowData)) {
+  if (rowData.numberOfPins < 0) {
     return <div className='red help' title={t('errors.failedToFetchTitle')}>{t('errors.failedToFetch')}</div>
   }
   return <div className={rowData.numberOfPins >= 0 ? '' : 'gray'}>{rowData.numberOfPins >= 0 ? rowData.numberOfPins : `${(t('app:terms:loading'))}...`}</div>

--- a/src/components/pinning-manager/pinning-manager-service-modal/PinningManagerServiceModal.js
+++ b/src/components/pinning-manager/pinning-manager-service-modal/PinningManagerServiceModal.js
@@ -22,7 +22,6 @@ const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service,
   const onSubmit = async data => {
     try {
       await doAddPinningService(data)
-      clearErrors('apiValidation')
       onSuccess()
     } catch (error) {
       console.error(error)
@@ -32,10 +31,13 @@ const PinningManagerServiceModal = ({ t, onLeave, onSuccess, className, service,
       })
     }
   }
+  const cleanErrors = () => {
+    clearErrors('apiValidation')
+  }
 
   return (
     <Modal {...props} className={className} onCancel={onLeave} style={{ maxWidth: '34em' }}>
-      <form onSubmit={handleSubmit(onSubmit)}>
+      <form onSubmit={handleSubmit(onSubmit)} onChange={cleanErrors}>
         <ModalBody>
           <p>{ t('pinningServiceModal.title') }</p>
 


### PR DESCRIPTION
Fixes #1816: now, when the input changes, we clear the errors from the form. The issue was that `handleSubmit` was not calling our actual `onSubmit` function since there were validation errors.

Regarding the second issue described by OP in https://github.com/ipfs/ipfs-webui/issues/1816#issuecomment-882104784, I could not reproduce.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>