### PR TITLE
Adding CrustPinner to the default pinning services list

### DIFF
--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -7,6 +7,12 @@ const pinningServiceTemplates = [
     icon: 'https://dweb.link/ipfs/QmVYXV4urQNDzZpddW4zZ9PGvcAbF38BnKWSgch3aNeViW?filename=pinata.svg',
     apiEndpoint: 'https://api.pinata.cloud/psa',
     visitServiceUrl: 'https://pinata.cloud/documentation#PinningServicesAPI'
+  },
+  {
+    name: 'CrustPinner',
+    icon: 'https://ipfs-hk.decoo.io/ipfs/QmRf1sssyxJqr4unHd7PP2pSSmYvaKT2ajoFHhMTpzKocu?filename=crust.svg',
+    apiEndpoint: 'https://api.decoo.io/psa',
+    visitServiceUrl: 'https://wiki.decoo.io/pinningServicesApi'
   }
 ]
 


### PR DESCRIPTION
Inspired by https://docs.ipfs.io/how-to/work-with-pinning-services/#create-your-own-pinning-service, we've built a remote pinning service based on self-hosted IPFS nodes and Crust Network, and would like to contribute to the default pinning service list of IPFS Web UI.


**Who we are**

This pinning service is contributed by [Crust Network](https://crust.network/) and [Decoo Technologies](https://decoo.io/), both of which are funded by [DCF (Decentralized Cloud Foundation)](https://decloudf.com/). 

Crust Network is a decentralized storage network based on IPFS and Substrate,  and provides decentralized IPFS Pin service. Decoo works closely with Crust to provide this remote IPFS Pinning Service according to the [pinning service spec](https://ipfs.github.io/pinning-services-api-spec/).


**How will CrustPinner display on Web UI**

When user click '+ Add Service', CrustPinner will display next to Pinata in the default pinning service list:
https://ipfs-hk.decoo.io/ipfs/QmVwPyzZKtnpnwSouyD8JtJfSdLn3SLAVbZAVNb8cd5bAB

Likewise, user could click to configure and add CrustPinner:
https://ipfs-hk.decoo.io/ipfs/QmNuYf941hLrHPV8XV5dAv9pSX5e4wQBA1Rg6biumBtdTi


**How to get access token**

User could sign up on https://decoo.io to get the access token. Also, they could visit https://wiki.decoo.io/pinningServicesApi to get more illustrations on the pinning service.


**Additional context**

For additional information, you can contact us at hi@crust.network or hi@decoo.io. We are willing to contribute and open for discussion. 
