### PR TITLE
feat: check if gateway is valid using image

### DIFF
--- a/src/components/public-gateway-form/PublicGatewayForm.js
+++ b/src/components/public-gateway-form/PublicGatewayForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import Button from '../button/Button'
-import { checkValidHttpUrl, DEFAULT_GATEWAY } from '../../bundles/gateway'
+import { checkValidHttpUrl, checkViaImgSrc, DEFAULT_GATEWAY } from '../../bundles/gateway'
 
 const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => {
   const [value, setValue] = useState(publicGateway)
@@ -26,6 +26,14 @@ const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => {
 
   const onSubmit = async (event) => {
     event.preventDefault()
+
+    try {
+      await checkViaImgSrc(value)
+    } catch (e) {
+      setShowFailState(true)
+      return
+    }
+
     doUpdatePublicGateway(value)
   }
 


### PR DESCRIPTION
Closes #1844 by using the same code we use in Companion (check mentioned issue).

It verifies if the gateway is valid only when submitting. I feel like validating on change would be better in terms of UX, but it can also be problematic as we have a 15 seconds timeout to account for the gateway to fetch the actual content.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>