### PR TITLE
Fix navbar links to the github repo.

### DIFF
--- a/src/navigation/NavBar.js
+++ b/src/navigation/NavBar.js
@@ -51,7 +51,7 @@ const NavLink = ({
 }
 
 export const NavBar = ({ t }) => {
-  const codeUrl = 'https://github.com/ipfs-shipyard/ipfs-webui'
+  const codeUrl = 'https://github.com/ipfs/ipfs-webui'
   const bugsUrl = `${codeUrl}/issues`
   const gitRevision = process.env.REACT_APP_GIT_REV
   const revisionUrl = `${codeUrl}/commit/${gitRevision}`


### PR DESCRIPTION
These links at the bottom:

![image](https://user-images.githubusercontent.com/700142/133117947-18c7ca1e-7439-4cfd-a314-3ce020efa151.png)

Currently redirect does not work for `Revision` link and we get 404 page there.