### PR TITLE
fix: missing ReleaseLink in go-ipfs version

### DIFF
--- a/src/components/version-link/VersionLink.js
+++ b/src/components/version-link/VersionLink.js
@@ -42,8 +42,8 @@ const VersionLink = ({ agentVersion }) => {
 
 const ReleaseLink = ({ agent, version }) => {
   if (!version) return ''
-  if (agent === 'js-ipfs') {
-    const releaseUrl = `${providers['js-ipfs'].url}/releases/tag/v${version}`
+  if (Object.prototype.hasOwnProperty.call(providers, agent)) {
+    const releaseUrl = `${providers[agent].url}/releases/tag/v${version}`
     return (
       <a href={releaseUrl} className='link blue ml2' target='_blank' rel='noopener noreferrer'>
         v{version}


### PR DESCRIPTION
Closes #1864

I chose to alter the if statement instead of adding another one. That way if in the future a provider needs to be added (say for example rust-ipfs), then you can simple append that URL to the providers object, only changing code in one place.