### PR TITLE
fix: replace .substr by .substring

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -68,7 +68,7 @@ const cumulativeSize = async (ipfs, cidOrPath) => {
 // TODO: use sth else
 export const realMfsPath = (path) => {
   if (path.startsWith('/files')) {
-    return path.substr('/files'.length) || '/'
+    return path.substring('/files'.length) || '/'
   }
 
   return path

--- a/src/bundles/files/utils.js
+++ b/src/bundles/files/utils.js
@@ -209,7 +209,7 @@ export const infoFromPath = (path, uriDecode = true) => {
    * @param {string} prefix
    */
   const check = (prefix) => {
-    info.realPath = info.path.substr(prefix.length).trim() || '/'
+    info.realPath = info.path.substring(prefix.length).trim() || '/'
     info.isRoot = info.realPath === '/'
   }
 

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -177,7 +177,7 @@ class Modals extends React.Component {
       case cliCmdKeys.ADD_DIRECTORY:
       case cliCmdKeys.CREATE_NEW_DIRECTORY:
       case cliCmdKeys.FROM_IPFS:
-        return cliCommandList[action](root.substr('/files'.length))
+        return cliCommandList[action](root.substring('/files'.length))
       case cliCmdKeys.DELETE_FILE_FROM_IPFS:
       case cliCmdKeys.REMOVE_FILE_FROM_IPFS:
         return cliCommandList[action](path)


### PR DESCRIPTION
`.substr` is deprecated: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>