### PR TITLE
refactor: on-demand remote pin status checks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10952,7 +10952,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
       "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-      "dev": true,
+      "devOptional": true,
       "engines": [
         "node >= 0.8.0"
       ],
@@ -29709,7 +29709,6 @@
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
-      "dev": true,
       "dependencies": {
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
@@ -32346,7 +32345,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -32361,7 +32359,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
       "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -32377,7 +32374,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -32389,7 +32385,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -32398,7 +32393,6 @@
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
       "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-      "dev": true,
       "dependencies": {
         "@jest/core": "^26.6.3",
         "@jest/test-result": "^26.6.2",
@@ -32425,7 +32419,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -45520,7 +45513,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
       "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "debug": "^3.2.5",
         "eventsource": "^1.0.7",
@@ -45534,7 +45527,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -45543,7 +45536,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/sockjs/node_modules/websocket-driver": {
       "version": "0.7.4",
@@ -47633,7 +47626,6 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
       "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -49137,7 +49129,7 @@
       "version": "2.25.1",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.1.tgz",
       "integrity": "sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -49149,13 +49141,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
       "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/webpack-hot-middleware/node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -53106,7 +53098,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@ipld/car": {
       "version": "3.1.16",
@@ -57797,7 +57790,8 @@
     "@tableflip/react-dropdown": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@tableflip/react-dropdown/-/react-dropdown-1.3.0.tgz",
-      "integrity": "sha512-Cm2bK5viLNx6/mrz1b6OpWc2sKXgmBFfTBR/Tqr3wnOdTggD90n7si9HDcojdQ4PvLlo0CFDFUDpKzYnUUl32Q=="
+      "integrity": "sha512-Cm2bK5viLNx6/mrz1b6OpWc2sKXgmBFfTBR/Tqr3wnOdTggD90n7si9HDcojdQ4PvLlo0CFDFUDpKzYnUUl32Q==",
+      "requires": {}
     },
     "@tableflip/react-inspector": {
       "version": "2.3.0",
@@ -58691,7 +58685,8 @@
     "acorn-jsx": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
-      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng=="
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -58815,12 +58810,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "alphanum-sort": {
       "version": "1.0.2",
@@ -58865,7 +58862,7 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ansi-html-community/-/ansi-html-community-0.0.8.tgz",
       "integrity": "sha512-1APHAyr3+PCamwNw3bXCPp4HFLONZt/yIH0sZp0/469KWNTEy+qN5jQ3GVX6DMZ1UXAi34yVwtTeaG/HpBuuzw==",
-      "dev": true
+      "devOptional": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -58909,7 +58906,8 @@
         "native-abort-controller": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA=="
+          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+          "requires": {}
         }
       }
     },
@@ -59884,7 +59882,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
-      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
+      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
+      "requires": {}
     },
     "babel-plugin-react-docgen": {
       "version": "4.2.1",
@@ -60370,7 +60369,8 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.6.0.tgz",
       "integrity": "sha512-57nLqKj4ShsDwFJWJsM4sZx6u60WbCge35rWRSevUwqxDtRwwxiKAO800zD2upPv4CfdWjQp//wSLar35nDKvA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "base64-js": {
       "version": "1.3.1",
@@ -63656,7 +63656,8 @@
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
-          "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw=="
+          "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
+          "requires": {}
         }
       }
     },
@@ -64843,7 +64844,8 @@
       "version": "14.1.1",
       "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz",
       "integrity": "sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.4",
@@ -65236,13 +65238,15 @@
     "eslint-plugin-react-hooks": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ=="
+      "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
+      "requires": {}
     },
     "eslint-plugin-standard": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-4.1.0.tgz",
       "integrity": "sha512-ZL7+QRixjTR6/528YNGyDotyffm5OQst/sGxKDwGb9Uqs4In5Egi4+jbobhqJoyoCM6/7v/1A5fhQ7ScMtDjaQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-testing-library": {
       "version": "3.10.1",
@@ -68661,7 +68665,8 @@
     "i18next-icu": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/i18next-icu/-/i18next-icu-2.0.3.tgz",
-      "integrity": "sha512-sZ0VCWDnHysUYQL8j/0rVOxv6rLR+SBoaqQQ2UVNfLyJCuf/bAjYPkoUQgyuDkWFo1xZjeCf4G6GBNr7gD61bQ=="
+      "integrity": "sha512-sZ0VCWDnHysUYQL8j/0rVOxv6rLR+SBoaqQQ2UVNfLyJCuf/bAjYPkoUQgyuDkWFo1xZjeCf4G6GBNr7gD61bQ==",
+      "requires": {}
     },
     "i18next-localstorage-backend": {
       "version": "3.1.3",
@@ -69047,13 +69052,15 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
           "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -69348,7 +69355,8 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
           "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "uint8arrays": {
           "version": "3.0.0",
@@ -69711,13 +69719,15 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
           "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -70148,13 +70158,15 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
           "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -70367,13 +70379,15 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
           "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -70541,13 +70555,15 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
           "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -71068,7 +71084,8 @@
         "native-abort-controller": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA=="
+          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+          "requires": {}
         },
         "varint": {
           "version": "6.0.0",
@@ -71439,7 +71456,8 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.4.tgz",
           "integrity": "sha512-zp8yev7nxczDJMoP6pDxyD20IU0T22eX8VwN2ztDccKvSZhRaV33yP1BGwKSZfXuqWUzsXopVFjBdau9OOAwMQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "parse-duration": {
           "version": "1.0.2",
@@ -71804,7 +71822,8 @@
         "native-abort-controller": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
-          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA=="
+          "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
+          "requires": {}
         },
         "web-encoding": {
           "version": "1.1.0",
@@ -73942,7 +73961,6 @@
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest/-/jest-26.6.3.tgz",
       "integrity": "sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==",
-      "dev": true,
       "requires": {
         "@jest/core": "^26.6.3",
         "import-local": "^3.0.2",
@@ -73953,7 +73971,6 @@
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
           }
@@ -73962,7 +73979,6 @@
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
           "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
             "supports-color": "^7.1.0"
@@ -73972,7 +73988,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -73980,14 +73995,12 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "jest-cli": {
           "version": "26.6.3",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-26.6.3.tgz",
           "integrity": "sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==",
-          "dev": true,
           "requires": {
             "@jest/core": "^26.6.3",
             "@jest/test-result": "^26.6.2",
@@ -74008,7 +74021,6 @@
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -74823,14 +74835,16 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
           "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
     "jest-pnp-resolver": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
-      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w=="
+      "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
+      "requires": {}
     },
     "jest-process-manager": {
       "version": "0.3.1",
@@ -78140,13 +78154,15 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
           "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -78321,13 +78337,15 @@
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/native-abort-controller/-/native-abort-controller-1.0.3.tgz",
           "integrity": "sha512-fd5LY5q06mHKZPD5FmMrn7Lkd2H018oBGKNOAdLpctBDEPFKsfJ1nX9ke+XRa8PEJJpjqrpQkGjq2IZ27QNmYA==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "native-fetch": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/native-fetch/-/native-fetch-3.0.0.tgz",
           "integrity": "sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "node-fetch": {
           "version": "https://registry.npmjs.org/@achingbrain/node-fetch/-/node-fetch-2.6.7.tgz",
@@ -81222,7 +81240,8 @@
           "version": "7.5.4",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.4.tgz",
           "integrity": "sha512-zP9z6GXm6zC27YtspwH99T3qTG7bBFv2VIkeHstMLrLlDJuzA7tQ5ls3OJ1hOGGCzTQPniNJoHXIAOS0Jljohg==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -83136,7 +83155,8 @@
     "react-country-flag": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/react-country-flag/-/react-country-flag-1.1.0.tgz",
-      "integrity": "sha512-Z6LW4U+qeH0X0d1o02aZUevRyk5Z4ZQmp1ResWkh/4z6kvjBqg9otYyxBAUtvElpgfQiP61cSZ2/XZ+pLjBPDw=="
+      "integrity": "sha512-Z6LW4U+qeH0X0d1o02aZUevRyk5Z4ZQmp1ResWkh/4z6kvjBqg9otYyxBAUtvElpgfQiP61cSZ2/XZ+pLjBPDw==",
+      "requires": {}
     },
     "react-debounce-render": {
       "version": "5.0.0",
@@ -83486,7 +83506,8 @@
     "react-hook-form": {
       "version": "6.14.2",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.14.2.tgz",
-      "integrity": "sha512-GgDUuT3Yfhl1BOcMl862uAFbCixSomtm3CVlQQ1qVu9Tq5BN2uUIRUIXP8l2Gy99eLUrBqU9x4E7N+si9cnvaw=="
+      "integrity": "sha512-GgDUuT3Yfhl1BOcMl862uAFbCixSomtm3CVlQQ1qVu9Tq5BN2uUIRUIXP8l2Gy99eLUrBqU9x4E7N+si9cnvaw==",
+      "requires": {}
     },
     "react-hotkeys": {
       "version": "2.0.0",
@@ -84656,7 +84677,8 @@
     "redux-bundler-react": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/redux-bundler-react/-/redux-bundler-react-1.2.0.tgz",
-      "integrity": "sha512-vyZMnt+uXyhihoZu8CyEQOfJIbhvl+yhvrL+WB+yo6kckYPBXOfXNssiviHrOb49BSWb30BRGQ6HX/ydk39Tvg=="
+      "integrity": "sha512-vyZMnt+uXyhihoZu8CyEQOfJIbhvl+yhvrL+WB+yo6kckYPBXOfXNssiviHrOb49BSWb30BRGQ6HX/ydk39Tvg==",
+      "requires": {}
     },
     "reflect.ownkeys": {
       "version": "0.2.0",
@@ -86227,7 +86249,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.4.0.tgz",
       "integrity": "sha512-5zaLyO8/nri5cua0VtOrFXBPK1jbL4+1cebT/mmKA1E1ZXOvJrII75bPu0l0k843G/+iAbhEqzyKr0w/eCCj7g==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "debug": "^3.2.5",
         "eventsource": "^1.0.7",
@@ -86241,7 +86263,7 @@
           "version": "3.2.7",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
           "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -86250,7 +86272,7 @@
           "version": "2.1.3",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
           "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-          "dev": true
+          "devOptional": true
         }
       }
     },
@@ -87889,14 +87911,14 @@
     "typescript": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
-      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
-      "dev": true
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg=="
     },
     "typeson": {
       "version": "5.18.2",
       "resolved": "https://registry.npmjs.org/typeson/-/typeson-5.18.2.tgz",
       "integrity": "sha512-Vetd+OGX05P4qHyHiSLdHZ5Z5GuQDrHHwSdjkqho9NSCYVSLSfRMjklD/unpHH8tXBR9Z/R05rwJSuMpMFrdsw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "typeson-registry": {
       "version": "1.0.0-alpha.38",
@@ -88398,7 +88420,8 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.5.tgz",
       "integrity": "sha512-gN3vgMISAgacF7sqsLPByqoePooY3n2emTH59Ur5d/M8eg4WTWu1xp8i8DHjohftIyEx0S08RiYxbffr4j8Peg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.0.4",
@@ -89147,7 +89170,7 @@
       "version": "2.25.1",
       "resolved": "https://registry.npmjs.org/webpack-hot-middleware/-/webpack-hot-middleware-2.25.1.tgz",
       "integrity": "sha512-Koh0KyU/RPYwel/khxbsDz9ibDivmUbrRuKSSQvW42KSDdO4w23WI3SkHpSUKHE76LrFnnM/L7JCrpBwu8AXYw==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "ansi-html-community": "0.0.8",
         "html-entities": "^2.1.0",
@@ -89159,13 +89182,13 @@
           "version": "2.3.2",
           "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.3.2.tgz",
           "integrity": "sha512-c3Ab/url5ksaT0WyleslpBEthOzWhrjQbg75y7XUsfSzi3Dgzt0l8w5e7DylRn15MTlMMD58dTfzddNS2kcAjQ==",
-          "dev": true
+          "devOptional": true
         },
         "strip-ansi": {
           "version": "6.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
           "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-          "dev": true,
+          "devOptional": true,
           "requires": {
             "ansi-regex": "^5.0.1"
           }
@@ -89702,7 +89725,8 @@
     "ws": {
       "version": "7.4.6",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+      "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/public/locales/en/notify.json
+++ b/public/locales/en/notify.json
@@ -4,7 +4,7 @@
   "ipfsInvalidApiAddress": "The provided IPFS API address is invalid.",
   "ipfsConnectSuccess": "Successfully connected to the IPFS API address",
   "ipfsConnectFail": "Unable to connect to the provided IPFS API address",
-  "ipfsPinFail": "Unable to set pinning. Try again, or see the browser console for more info.",
+  "ipfsPinFail": "Unable to set pinning at {serviceName}: {errorMsg}",
   "ipfsIsBack": "Normal IPFS service has resumed. Enjoy!",
   "folderExists": "An item with that name already exists. Please choose another.",
   "filesFetchFailed": "Failed to get those files. Please check the path and try again.",

--- a/public/locales/en/notify.json
+++ b/public/locales/en/notify.json
@@ -4,7 +4,7 @@
   "ipfsInvalidApiAddress": "The provided IPFS API address is invalid.",
   "ipfsConnectSuccess": "Successfully connected to the IPFS API address",
   "ipfsConnectFail": "Unable to connect to the provided IPFS API address",
-  "ipfsPinFail": "Unable to set pinning at {serviceName}: {errorMsg}",
+  "ipfsPinFailReason": "Unable to set pinning at {serviceName}: {errorMsg}",
   "ipfsIsBack": "Normal IPFS service has resumed. Enjoy!",
   "folderExists": "An item with that name already exists. Please choose another.",
   "filesFetchFailed": "Failed to get those files. Please check the path and try again.",

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -560,21 +560,6 @@ const actions = () => ({
   doFilesClear: () => send({ type: ACTIONS.CLEAR_ALL }),
 
   /**
-   * Gets total size of the local pins. On successful completion `state.mfsSize` will get
-   * updated.
-   */
-  doPinsStatsGet: () => perform(ACTIONS.PINS_SIZE_GET, async (ipfs) => {
-    const pinsSize = -1 // TODO: right now calculating size of all pins is too expensive (requires ipfs.files.stat per CID)
-    let numberOfPins = 0
-
-    for await (const _ of ipfs.pin.ls({ type: 'recursive' })) { // eslint-disable-line  no-unused-vars
-      numberOfPins++
-    }
-
-    return { pinsSize, numberOfPins }
-  }),
-
-  /**
    * Gets size of the MFS. On successful completion `state.mfsSize` will get
    * updated.
    */

--- a/src/bundles/notify.js
+++ b/src/bundles/notify.js
@@ -128,7 +128,7 @@ const notify = {
         return 'ipfsInvalidApiAddress'
       }
       if (eventId === 'IPFS_PIN_FAILED') {
-        return 'ipfsPinFail'
+        return 'ipfsPinFailReason'
       }
 
       if (eventId === 'FILES_EVENT_FAILED') {

--- a/src/bundles/notify.js
+++ b/src/bundles/notify.js
@@ -69,8 +69,17 @@ const notify = {
         eventId: `experimentsErrors.${action.payload.key}`
       }
     }
+    if (action.type === 'IPFS_PIN_FAILED') {
+      return {
+        ...state,
+        show: true,
+        error: true,
+        msgArgs: action.msgArgs,
+        eventId: action.type
+      }
+    }
 
-    if (action.type === 'IPFS_CONNECT_FAILED' || action.type === 'IPFS_PIN_FAILED') {
+    if (action.type === 'IPFS_CONNECT_FAILED') {
       return {
         ...state,
         show: true,

--- a/src/components/notify/Notify.js
+++ b/src/components/notify/Notify.js
@@ -4,12 +4,12 @@ import { withTranslation } from 'react-i18next'
 import Toast from './Toast'
 
 const Notify = ({ t, notify, notifyI18nKey, doNotifyDismiss }) => {
-  const { show, error } = notify
+  const { show, error, msgArgs } = notify
   if (!show) return null
 
   return (
     <Toast error={error} onDismiss={doNotifyDismiss}>
-      {t(notifyI18nKey)}
+      {t(notifyI18nKey, msgArgs)}
     </Toast>
   )
 }

--- a/src/components/pinning-manager/PinningManager.js
+++ b/src/components/pinning-manager/PinningManager.js
@@ -21,7 +21,7 @@ import './PinningManager.css'
 const ROW_HEIGHT = 50
 const HEADER_HEIGHT = 32
 
-export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesSupported, doFetchPinningServices, doPinsStatsGet, doRemovePinningService, pinsSize, numberOfPins, t }) => {
+export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesSupported, doFetchPinningServices, doFetchPinningServicesStats, doRemovePinningService, pinsSize, numberOfPins, t }) => {
   const [isModalOpen, setModalOpen] = useState(false)
   const [isToggleModalOpen, setToggleModalOpen] = useState(false)
   const onModalOpen = () => setModalOpen(true)
@@ -33,19 +33,10 @@ export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesS
     sortBy: 'addedAt',
     sortDirection: SortDirection.ASC
   })
-  useEffect(() => {
-    (async () => {
-      try {
-        ipfsReady && await doPinsStatsGet()
-      } catch (e) {
-        console.error('doPinsStatsGet error', e)
-      }
-    })()
-  }, [doPinsStatsGet, ipfsReady])
 
   useEffect(() => {
-    ipfsReady && doFetchPinningServices()
-  }, [ipfsReady, doFetchPinningServices])
+    ipfsReady && doFetchPinningServices() && doFetchPinningServicesStats()
+  }, [ipfsReady, doFetchPinningServices, doFetchPinningServicesStats])
 
   const localPinning = useMemo(() =>
     ({ name: t('localPinning'), type: 'LOCAL', totalSize: pinsSize, numberOfPins }),
@@ -96,6 +87,7 @@ export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesS
         <AutoUploadModal className='outline-0' onLeave={() => {
           onToggleModalClose()
           doFetchPinningServices()
+          doFetchPinningServicesStats()
         }} t={t} name={isToggleModalOpen} service={sortedServices.find(s => s.name === isToggleModalOpen)} />
       </Overlay>
 
@@ -103,6 +95,7 @@ export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesS
         <PinningModal className='outline-0' onLeave={() => {
           onModalClose()
           doFetchPinningServices()
+          doFetchPinningServicesStats()
         }} t={t} />
       </Overlay>
     </Fragment>
@@ -193,13 +186,13 @@ const OptionsCell = ({ doRemovePinningService, name, visitServiceUrl, autoUpload
 }
 
 export default connect(
-  'doPinsStatsGet',
   'selectIpfsReady',
   'selectPinsSize',
   'selectNumberOfPins',
   'selectPinningServices',
   'selectArePinningServicesSupported',
   'doFetchPinningServices',
+  'doFetchPinningServicesStats',
   'doRemovePinningService',
   PinningManager
 )

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -50,11 +50,12 @@ const FilesPage = ({
     }
   }, [ipfsConnected, filesPathInfo, doFilesFetch])
 
+  /* TODO: uncomment below if we ever want automatic remote pin check
+  *  (it was disabled for now due to https://github.com/ipfs/ipfs-desktop/issues/1954)
   useEffect(() => {
-    if (pinningServices.some(service => service.online)) {
-      files && files.content && doFetchRemotePins(files.content)
-    }
+    files && files.content && doFetchRemotePins(files.content)
   }, [files, pinningServices, doFetchRemotePins])
+  */
 
   const onDownload = async (files) => {
     if (downloadProgress !== null) {

--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -18,7 +18,7 @@ import { NativeTypes } from 'react-dnd-html5-backend'
 
 const File = ({
   name, type, size, cid, path, pinned, t, selected, focused, translucent, coloured, cantSelect, cantDrag, isMfs, isRemotePin,
-  onAddFiles, onMove, onSelect, onNavigate, handleContextMenuClick
+  onAddFiles, onMove, onSelect, onNavigate, onSetPinning, handleContextMenuClick
 }) => {
   const dotsWrapper = useRef()
 
@@ -126,13 +126,18 @@ const File = ({
           </div>
         </button>
 
-        <div className='ph2 pv1 flex-none dn db-l tr mw3 w-20 transition-all'>
-          { pinned && !isRemotePin && <div className='br-100 o-70' title={t('pinned')} style={{ width: '2rem', height: '2rem' }}>
-            <GlyphPin className='fill-aqua' />
-          </div> }
-          { isRemotePin && <div className='br-100 o-70' title={t('pinnedRemotely')} style={{ width: '2rem', height: '2rem' }}>
-            <GlyphPinCloud className='fill-aqua' />
-          </div> }
+        <div className='ph2 pv1 flex-none hide-child dn db-l tr mw3 w-20 transition-all'>
+          <button className='ph2 db button-inside-focus' style={{ width: '2.5rem', height: '2rem' }} onClick={() => onSetPinning([{ cid, pinned }])}>
+            { pinned && !isRemotePin && <div className='br-100 o-70' title={t('pinned')} style={{ width: '2rem', height: '2rem' }}>
+              <GlyphPin className='fill-aqua' />
+            </div> }
+            { isRemotePin && <div className='br-100 o-70' title={t('pinnedRemotely')} style={{ width: '2rem', height: '2rem' }}>
+              <GlyphPinCloud className='fill-aqua' />
+            </div> }
+            { !pinned && !isRemotePin && <div className='br-100 hide-child' title={t('app:actions.setPinning')} style={{ width: '2rem', height: '2rem' }}>
+              <GlyphPin className='fill-gray-muted child' />
+            </div> }
+          </button>
         </div>
         <div className='size pl2 pr4 pv1 flex-none f6 dn db-l tr charcoal-muted w-10 mw4'>
           {size}

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -32,8 +32,8 @@ const mergeRemotePinsIntoFiles = (files, remotePins) => {
 }
 
 export const FilesList = ({
-  className, files, pins, remotePins, filesSorting, updateSorting, downloadProgress, filesIsFetching, filesPathInfo, showLoadingAnimation,
-  onShare, onSetPinning, onInspect, onDownload, onRemove, onRename, onNavigate, onRemotePinClick, onAddFiles, onMove, handleContextMenuClick, t
+  className, files, pins, pinningServices, remotePins, filesSorting, updateSorting, downloadProgress, filesIsFetching, filesPathInfo, showLoadingAnimation,
+  onShare, onSetPinning, onInspect, onDownload, onRemove, onRename, onNavigate, onRemotePinClick, onAddFiles, onMove, doFetchRemotePins, handleContextMenuClick, t
 }) => {
   const [selected, setSelected] = useState([])
   const [focused, setFocused] = useState(null)
@@ -41,6 +41,7 @@ export const FilesList = ({
   const [allFiles, setAllFiles] = useState(mergeRemotePinsIntoFiles(files, remotePins))
   const listRef = useRef()
   const filesRefs = useRef([])
+  const refreshPinCache = true // manually clicking on Pin Status column skips cache and updates remote status
 
   const [{ canDrop, isOver, isDragging }, drop] = useDrop({
     accept: NativeTypes.FILE,
@@ -244,6 +245,7 @@ export const FilesList = ({
           onSelect={toggleOne}
           onNavigate={onNavigateHandler}
           onAddFiles={onAddFiles}
+          onSetPinning={onSetPinning}
           onMove={move}
           focused={focused === listItem.name}
           selected={selected.indexOf(listItem.name) !== -1}
@@ -277,9 +279,10 @@ export const FilesList = ({
               </button>
             </div>
             <div className='pl2 pr1 tr f6 flex-none dn db-l mw4'>
-              <span>
-                {t('app:terms.pinStatus')}
-              </span>
+              { pinningServices && pinningServices.length
+                ? <button aria-label={t('app:terms.pinStatus')} onClick={() => doFetchRemotePins(files, refreshPinCache)}>{t('app:terms.pinStatus')}</button>
+                : <>{t('app:terms.pinStatus')}</>
+              }
             </div>
             <div className='pl2 pr4 tr f6 flex-none dn db-l mw4 w-10'>
               <button aria-label={ t('sortBy', { name: t('size') })} onClick={changeSort(sorts.BY_SIZE)}>
@@ -371,6 +374,8 @@ FileList.defaultProps = {
 
 export default connect(
   'selectPins',
+  'selectPinningServices',
+  'doFetchRemotePins',
   'selectFilesIsFetching',
   'selectFilesSorting',
   'selectFilesPathInfo',

--- a/src/files/files-list/FilesList.js
+++ b/src/files/files-list/FilesList.js
@@ -23,9 +23,9 @@ const addFiles = async (filesPromise, onAddFiles) => {
 }
 
 const mergeRemotePinsIntoFiles = (files, remotePins) => {
-  const remotePinsCids = remotePins.map(c => c.cid.string)
+  const remotePinsCids = remotePins.map(id => id.split(':').at(-1))
 
-  return files.map(f => remotePinsCids.includes(f.cid?.string) ? ({
+  return files.map(f => remotePinsCids.includes(f.cid?.toString()) ? ({
     ...f,
     isRemotePin: true
   }) : f)

--- a/src/files/modals/pinning-modal/PinningModal.js
+++ b/src/files/modals/pinning-modal/PinningModal.js
@@ -21,8 +21,10 @@ const PinIcon = ({ icon, index }) => {
   return <GlyphPin width={32} height={32} className={glyphClass}/>
 }
 
-export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningServices, doGetFileSizeThroughCid, doSelectRemotePinsForFile, doFetchPinningServices, className, ...props }) => {
-  const selectedRemoteServices = useMemo(() => doSelectRemotePinsForFile(file), [doSelectRemotePinsForFile, file])
+export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningServices, remotePins, notRemotePins, doGetFileSizeThroughCid, doSelectRemotePinsForFile, doFetchPinningServices, doFetchRemotePins, className, ...props }) => {
+  // const selectedRemoteServices = useMemo(() => doSelectRemotePinsForFile(file, pinningServices, remotePins), [doSelectRemotePinsForFile, pinningServices, remotePins, file])
+  const selectedRemoteServices = useMemo(() => doSelectRemotePinsForFile(file, remotePins, notRemotePins), [doSelectRemotePinsForFile, file, remotePins, notRemotePins])
+  // const selectedRemoteServices = doSelectRemotePinsForFile(file)
   const [selectedServices, setSelectedServices] = useState([...selectedRemoteServices, ...[file.pinned && 'local']])
   const [size, setSize] = useState(null)
 
@@ -30,15 +32,23 @@ export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningS
     doFetchPinningServices()
     const fetchSize = async () => setSize(await doGetFileSizeThroughCid(file.cid))
     fetchSize()
+    doFetchRemotePins([{ cid: file.cid }])
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [file])
+
+  useEffect(() => {
+    // Trigger status check for services without cached result
+    setSelectedServices([...selectedRemoteServices, ...[file.pinned && 'local']])
+  }, [file, selectedRemoteServices])
 
   const selectService = (key) => {
+    /*
     const service = pinningServices.find(s => s.name === key)
     if (service && !service.online) {
       // when a service is offline, click in noop
       return
     }
+    */
     if (selectedServices.indexOf(key) === -1) {
       return setSelectedServices([...selectedServices, key])
     }
@@ -55,11 +65,11 @@ export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningS
             <GlyphPin fill="currentColor" width={32} height={32} className="mr1 aqua flex-shrink-0"/>
             <p className="f5 w-100">{ t('pinningModal.localNode') }</p>
           </button>
-          { pinningServices.map(({ icon, name, online }, index) => (
+          { pinningServices.map(({ icon, name }, index) => (
             <button className="flex items-center pa1 hoverable-button" key={name} onClick={() => selectService(name)}>
-              <Checkbox className='pv3 pl3 pr1 flex-none' checked={selectedServices.includes(name)} style={{ pointerEvents: 'none' }} disabled={!online}/>
+              <Checkbox className='pv3 pl3 pr1 flex-none' checked={selectedServices.includes(name)} style={{ pointerEvents: 'none' }}/>
               <PinIcon index={index} icon={icon}/>
-              <p className={ online ? 'f6' : 'f6 red' }>{ name }</p>
+              <p className='f5'>{ name }</p>
             </button>
           ))}
         </div>
@@ -93,8 +103,11 @@ PinningModal.defaultProps = {
 
 export default connect(
   'selectPinningServices',
+  'selectRemotePins',
+  'selectNotRemotePins',
   'doSelectRemotePinsForFile',
   'doGetFileSizeThroughCid',
   'doFetchPinningServices',
+  'doFetchRemotePins',
   withTranslation('files')(PinningModal)
 )

--- a/src/files/modals/pinning-modal/PinningModal.js
+++ b/src/files/modals/pinning-modal/PinningModal.js
@@ -22,9 +22,7 @@ const PinIcon = ({ icon, index }) => {
 }
 
 export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningServices, remotePins, notRemotePins, doGetFileSizeThroughCid, doSelectRemotePinsForFile, doFetchPinningServices, doFetchRemotePins, className, ...props }) => {
-  // const selectedRemoteServices = useMemo(() => doSelectRemotePinsForFile(file, pinningServices, remotePins), [doSelectRemotePinsForFile, pinningServices, remotePins, file])
   const selectedRemoteServices = useMemo(() => doSelectRemotePinsForFile(file, remotePins, notRemotePins), [doSelectRemotePinsForFile, file, remotePins, notRemotePins])
-  // const selectedRemoteServices = doSelectRemotePinsForFile(file)
   const [selectedServices, setSelectedServices] = useState([...selectedRemoteServices, ...[file.pinned && 'local']])
   const [size, setSize] = useState(null)
 
@@ -42,13 +40,6 @@ export const PinningModal = ({ t, tReady, onCancel, onPinningSet, file, pinningS
   }, [file, selectedRemoteServices])
 
   const selectService = (key) => {
-    /*
-    const service = pinningServices.find(s => s.name === key)
-    if (service && !service.online) {
-      // when a service is offline, click in noop
-      return
-    }
-    */
     if (selectedServices.indexOf(key) === -1) {
       return setSelectedServices([...selectedServices, key])
     }

--- a/src/files/modals/remove-modal/RemoveModal.js
+++ b/src/files/modals/remove-modal/RemoveModal.js
@@ -27,7 +27,7 @@ const RemoveModal = ({ t, tReady, onCancel, onRemove, files, foldersCount, files
 
   useEffect(() => {
     (async () => {
-      const isPinned = files.some(f => remotePins.find(p => p.cid.string === f.cid.string))
+      const isPinned = files.some(f => remotePins.find(p => p.endsWith(f.cid.toString())))
       setRemotelyPinned(isPinned)
     })()
   })


### PR DESCRIPTION
This is bare minimum to restore remote pinning with rate-limited Pinata and close #1900
Not a perfect solution, but a fast-tracked fix to restore pinning functionality **_at all_** (right now Pinata is effectively broken in webui and ipfs-desktop – details in https://github.com/ipfs/ipfs-webui/issues/1900#issuecomment-1032030124).

Key changes:

- [x]  _Files_ screen does not make automatic requests to remote pinning service every time a new directory is opened
  - we progressively build a cache with remote pin states every time user opens "Set pinning" modal, and send requests only for files that we did not check the remote state before
  - we persist  the `pinning` bundle state with remote pin states with  `createCacheBundle` (src/bundles/index.js) and `persistActions` (src/bundles/pinning.js), which store data in browser's IndexedDB (uses `money-clip` as cache backend)
  - new users should not see any regression:  the pin would be added to the cache during pinning operation, and thanks to persisted cache, cloud pin will show every time _Files_ screen loads.
  - old users may need to manually go to "Set pinning" to trigger status fetch, but that is the best we can do and a fair compromise, given nothing worked before this.  
- [x] The expensive `ipfs pin remote service ls --stat` checks  are executed  only on _Settings_ screen – _Files_ does not need them.
- [x] Remote pin status check is triggered by opening "_Set pinning_"  modal via context menu or the pin icon, or by clicking on "Pin Status" column header.
  - [x] Clicking on "Pin Status" header bypassess remote pin status cache and forces online status re-check for all items in current directory (bit of a hidden feature / escape hatch for frustrated, existing users)
- [x] Errors returned by pinning service are now correctly reported to the user. The CLI and ipfs-webui users will now see the same error message:
  >  ![2022-02-09_17-41_1](https://user-images.githubusercontent.com/157609/153260889-6371d30e-f817-4893-a073-1fa982306159.png)
  >  ![2022-02-09_17-41](https://user-images.githubusercontent.com/157609/153260911-d72b4595-2163-4bdf-ac42-5890d2cc85af.png)