### PR TITLE
fix: fetch local pins stats

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,7 +109,7 @@
         "eslint-plugin-standard": "^4.0.1",
         "fake-indexeddb": "^3.1.2",
         "get-port": "^5.1.1",
-        "go-ipfs": "0.9.1",
+        "go-ipfs": "0.12.0",
         "http-proxy": "^1.18.1",
         "http-server": "^0.12.3",
         "ipfs": "0.58.3",
@@ -21933,14 +21933,13 @@
       }
     },
     "node_modules/go-ipfs": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.9.1.tgz",
-      "integrity": "sha512-69sDGENU7xEPDNytEzE+swKTNSLr+OJEfdEYQ41m91dzNyHyxABB4Rteg4uzsj34lTizjVI1m7Gld3g5Dgf6Ag==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.12.0.tgz",
+      "integrity": "sha512-rZbU4PsXbqzdqgH57G48MvLveV4i8StKPUHr49Kepm/z+/qwhg8jzHQVpiip/+28qd2gy3Cgiw1MremegHRvPw==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",
@@ -22113,15 +22112,6 @@
       "dev": true,
       "dependencies": {
         "lowercase-keys": "^2.0.0"
-      }
-    },
-    "node_modules/go-platform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
-      "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc=",
-      "dev": true,
-      "bin": {
-        "go-platform": "cli.js"
       }
     },
     "node_modules/good-listener": {
@@ -67693,13 +67683,12 @@
       }
     },
     "go-ipfs": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.9.1.tgz",
-      "integrity": "sha512-69sDGENU7xEPDNytEzE+swKTNSLr+OJEfdEYQ41m91dzNyHyxABB4Rteg4uzsj34lTizjVI1m7Gld3g5Dgf6Ag==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/go-ipfs/-/go-ipfs-0.12.0.tgz",
+      "integrity": "sha512-rZbU4PsXbqzdqgH57G48MvLveV4i8StKPUHr49Kepm/z+/qwhg8jzHQVpiip/+28qd2gy3Cgiw1MremegHRvPw==",
       "dev": true,
       "requires": {
         "cachedir": "^2.3.0",
-        "go-platform": "^1.0.0",
         "got": "^11.7.0",
         "gunzip-maybe": "^1.4.2",
         "hasha": "^5.2.2",
@@ -67824,12 +67813,6 @@
           }
         }
       }
-    },
-    "go-platform": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/go-platform/-/go-platform-1.0.0.tgz",
-      "integrity": "sha1-sF/2uSdAB9JGsWQjXwP39qWWJsc=",
-      "dev": true
     },
     "good-listener": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "eslint-plugin-standard": "^4.0.1",
     "fake-indexeddb": "^3.1.2",
     "get-port": "^5.1.1",
-    "go-ipfs": "0.9.1",
+    "go-ipfs": "0.12.0",
     "http-proxy": "^1.18.1",
     "http-server": "^0.12.3",
     "ipfs": "0.58.3",

--- a/src/bundles/files/consts.js
+++ b/src/bundles/files/consts.js
@@ -31,8 +31,6 @@ export const ACTIONS = {
   PIN_LIST: ('FILES_PIN_LIST'),
   /** @type {'FILES_SIZE_GET'} */
   SIZE_GET: ('FILES_SIZE_GET'),
-  /** @type {'FILES_PINS_SIZE_GET'} */
-  PINS_SIZE_GET: ('FILES_PINS_SIZE_GET'),
   /** @type {'FILES_DISMISS_ERRORS'} */
   DISMISS_ERRORS: ('FILES_DISMISS_ERRORS'),
   /** @type {'FILES_CLEAR_ALL'} */
@@ -60,8 +58,6 @@ export const IGNORED_FILES = [
 export const DEFAULT_STATE = {
   pageContent: null,
   mfsSize: -1,
-  pinsSize: 0,
-  numberOfPins: 0,
   pins: [],
   sorting: { // TODO: cache this
     by: SORTING.BY_NAME,

--- a/src/bundles/files/index.js
+++ b/src/bundles/files/index.js
@@ -98,22 +98,6 @@ const createFilesBundle = () => {
             return state
           }
         }
-        case ACTIONS.PINS_SIZE_GET: {
-          const { task, type } = action
-          const pinsSize = task.status === 'Exit' && task.result.ok
-            ? task.result.value.pinsSize
-            : 0
-
-          const numberOfPins = task.status === 'Exit' && task.result.ok
-            ? task.result.value.numberOfPins
-            : 0
-
-          return {
-            ...updateJob(state, task, type),
-            pinsSize,
-            numberOfPins
-          }
-        }
         case ACTIONS.SIZE_GET: {
           const { task, type } = action
           const mfsSize = task.status === 'Exit' && task.result.ok

--- a/src/bundles/files/protocol.ts
+++ b/src/bundles/files/protocol.ts
@@ -9,8 +9,6 @@ export type Model = {
   pins: string[]
   sorting: Sorting
   mfsSize: number
-  pinsSize: number
-  numberOfPins: number
 
   pending: PendingJob<any, any>[]
   finished: FinishedJob<any>[]

--- a/src/bundles/files/selectors.js
+++ b/src/bundles/files/selectors.js
@@ -45,16 +45,6 @@ const selectors = () => ({
   /**
    * @param {Model} state
    */
-  selectPinsSize: (state) => state.files.pinsSize,
-
-  /**
-   * @param {Model} state
-   */
-  selectNumberOfPins: (state) => state.files.numberOfPins,
-
-  /**
-   * @param {Model} state
-   */
   selectFilesIsFetching: (state) => state.files.pending.some(a => a.type === ACTIONS.FETCH),
 
   /**

--- a/src/components/pinning-manager/PinningManager.js
+++ b/src/components/pinning-manager/PinningManager.js
@@ -21,7 +21,7 @@ import './PinningManager.css'
 const ROW_HEIGHT = 50
 const HEADER_HEIGHT = 32
 
-export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesSupported, doFetchPinningServices, doFetchPinningServicesStats, doRemovePinningService, pinsSize, numberOfPins, t }) => {
+export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesSupported, doFetchPinningServices, doFetchPinningServicesStats, doFetchLocalPinsStats, doRemovePinningService, localPinsSize, localNumberOfPins, t }) => {
   const [isModalOpen, setModalOpen] = useState(false)
   const [isToggleModalOpen, setToggleModalOpen] = useState(false)
   const onModalOpen = () => setModalOpen(true)
@@ -35,12 +35,12 @@ export const PinningManager = ({ pinningServices, ipfsReady, arePinningServicesS
   })
 
   useEffect(() => {
-    ipfsReady && doFetchPinningServices() && doFetchPinningServicesStats()
-  }, [ipfsReady, doFetchPinningServices, doFetchPinningServicesStats])
+    ipfsReady && doFetchPinningServices() && doFetchPinningServicesStats() && doFetchLocalPinsStats()
+  }, [ipfsReady, doFetchPinningServices, doFetchPinningServicesStats, doFetchLocalPinsStats])
 
   const localPinning = useMemo(() =>
-    ({ name: t('localPinning'), type: 'LOCAL', totalSize: pinsSize, numberOfPins }),
-  [numberOfPins, pinsSize, t])
+    ({ name: t('localPinning'), type: 'LOCAL', totalSize: localPinsSize, numberOfPins: localNumberOfPins }),
+  [localNumberOfPins, localPinsSize, t])
 
   const sortedServices = useMemo(() =>
     (pinningServices || []).sort(sortByProperty(sortSettings.sortBy, sortSettings.sortDirection === SortDirection.ASC ? 1 : -1)),
@@ -187,12 +187,13 @@ const OptionsCell = ({ doRemovePinningService, name, visitServiceUrl, autoUpload
 
 export default connect(
   'selectIpfsReady',
-  'selectPinsSize',
-  'selectNumberOfPins',
+  'selectLocalPinsSize',
+  'selectLocalNumberOfPins',
   'selectPinningServices',
   'selectArePinningServicesSupported',
   'doFetchPinningServices',
   'doFetchPinningServicesStats',
+  'doFetchLocalPinsStats',
   'doRemovePinningService',
   PinningManager
 )


### PR DESCRIPTION
Fixes #1906: regression introduced in #1903, specifically by removing [local pin size calculation](https://github.com/ipfs/ipfs-webui/pull/1903/files#diff-7898dde76b2bbdcbb1d0fd5916ea316d6e7344901f01cbf5adb1822e140bc053), which is tied with the update of the amount of local pins.

Instead of just partially reverting the code, I added it to the pinning bundle and simplified, renamed and cleaned a few things.