### PR TITLE
fix: FilesExplorerForm icons for differing browser text sizes

### DIFF
--- a/src/files/explore-form/FilesExploreForm.js
+++ b/src/files/explore-form/FilesExploreForm.js
@@ -94,7 +94,7 @@ class FilesExploreForm extends React.Component {
             onClick={this.onInspect}
             bg='bg-teal'
             className='ExploreFormButton button-reset pv1 ph2 ba f7 fw4 white overflow-hidden tc' >
-            <StrokeIpld style={{ height: 24 }} className='dib fill-current-color v-mid' />
+            <StrokeIpld style={{ height: '2em' }} className='dib fill-current-color v-mid' />
             <span className='ml2'>{t('app:actions.inspect')}</span>
           </Button>
           <Button
@@ -104,7 +104,7 @@ class FilesExploreForm extends React.Component {
             title={t('app:actions.browse')}
             onClick={this.onBrowse}
             className='ExploreFormButton button-reset pv1 ph2 ba f7 fw4 white bg-gray overflow-hidden tc' >
-            <StrokeFolder style={{ height: 24 }} className='dib fill-current-color v-mid' />
+            <StrokeFolder style={{ height: '2em' }} className='dib fill-current-color v-mid' />
             <span className='ml2'>{t('app:actions.browse')}</span>
           </Button>
         </div>


### PR DESCRIPTION
I run my browser with a non-standard text size and I noticed that the `FilesExplorerForm` icons do not look correct. This changes the icon heights to relative units from the absolute (default) pixels.

Very small and very large text sizes *before* this change:

![very_small_broken](https://user-images.githubusercontent.com/475017/159617783-0304541d-28ce-407c-8047-bb1f1279bfc4.png)
![very_large_broken](https://user-images.githubusercontent.com/475017/159617799-c3c87051-14c3-4843-9c0b-8675177e404d.png)

After:

![very_small_fixed](https://user-images.githubusercontent.com/475017/159617813-52d140f1-c1a1-4008-bd9c-6dbcc1cd24f9.png)
![very_large_fixed](https://user-images.githubusercontent.com/475017/159617818-23429503-ed9b-4046-873a-184e49f6541e.png)

I am using the Dark Reader extension for the dark theme. It is not part of this PR.