### PR TITLE
fix: use gateway links to download standalone files

### DIFF
--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -62,10 +62,17 @@ const FilesPage = ({
       return downloadAbort()
     }
 
-    const updater = (v) => setDownloadProgress(v)
     const { url, filename, method } = await doFilesDownloadLink(files)
-    const { abort } = await downloadFile(url, filename, updater, method)
-    setDownloadAbort(() => abort)
+
+    if (method === 'GET') {
+      const link = document.createElement('a')
+      link.href = url
+      link.click()
+    } else {
+      const updater = (v) => setDownloadProgress(v)
+      const { abort } = await downloadFile(url, filename, updater, method)
+      setDownloadAbort(() => abort)
+    }
   }
   const onAddFiles = (raw, root = '') => {
     if (root === '') root = files.path

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -54,7 +54,7 @@ async function downloadSingle (file, gatewayUrl, apiUrl) {
     filename = `${name}.tar.gz`
     method = 'POST' // API is POST-only
   } else {
-    url = `${gatewayUrl}/ipfs/${file.cid}`
+    url = `${gatewayUrl}/ipfs/${file.cid}?download=true&filename=${file.name}`
     filename = file.name
     method = 'GET'
   }


### PR DESCRIPTION
In #1894 we tried to address #1887. However, doing that for all types of files is [blocked](https://github.com/ipfs/ipfs-webui/pull/1894#discussion_r786341423) by https://github.com/ipfs/go-ipfs/issues/7746. This PR does the same but only for standalone files. I think it's a good improvement and can mitigate the issues that we are trying to address.

I also don't understand why the CI is failing on "Installing Dependencies" as this PR changes nothing regarding dependencies.