### PR TITLE
fix: change "import" button label to "add" on files screen

### DIFF
--- a/src/files/file-input/FileInput.js
+++ b/src/files/file-input/FileInput.js
@@ -16,7 +16,7 @@ import { cliCmdKeys } from '../../bundles/files/consts'
 const AddButton = withTranslation('app')(
   ({ t, onClick }) => (
     <Button id='import-button' bg='bg-navy' color='white' className='f6 flex justify-center items-center' minWidth='100px' onClick={onClick}>
-      <span><span className='aqua'>+</span> {t('actions.import')}</span>
+      <span><span className='aqua'>+</span> {t('actions.add')}</span>
     </Button>
   )
 )


### PR DESCRIPTION
Changed "import" button label to "add" on files screen to better fit new folder option. As suggested by #1951.