### PR TITLE
fix: resolve issues with automated releases 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -229,7 +229,7 @@ jobs:
 
       # Update the version (npm version [major|minor|patch])
       - name: Run semantic release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
         run: |
           git config user.name "ipfs-gui-bot"
           git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,12 +81,12 @@ jobs:
       - run: echo ${{ github.ref }}
       - name: Create ipfs-webui.car file
         run: |
-          ipfs dag export ${{ steps.ipfs.outputs.cid }} > build/ipfs-webui_${{ github.sha }}.car
+          ipfs dag export ${{ steps.ipfs.outputs.cid }} > ipfs-webui_${{ github.sha }}.car
       - name: Attach produced build to Github Action
         uses: actions/upload-artifact@v2
         with:
           name: ipfs-webui_${{ github.sha }}.car
-          path: build/ipfs-webui_${{ github.sha }}.car
+          path: ipfs-webui_${{ github.sha }}.car
           if-no-files-found: error
 
       - name: Pin to estuary.tech
@@ -170,7 +170,6 @@ jobs:
   #    2. The 'publish-release-build.yml' workflow
   release:
     name: 'Run semantic release'
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [build, publishPreview, eslint, typecheck, test-e2e, test-unit]
     steps:
@@ -214,8 +213,23 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
 
+      - name: Download CAR artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: ipfs-webui_${{ github.sha }}.car
+
+      - name: Dry-run semantic release
+        if: github.ref != 'refs/heads/main'
+        run: |
+          git config user.name "ipfs-gui-bot"
+          git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"
+          npx semantic-release --ci --dry-run -b ${{ github.ref }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+
       # Update the version (npm version [major|minor|patch])
       - name: Run semantic release
+        if: github.ref == 'refs/heads/main'
         run: |
           git config user.name "ipfs-gui-bot"
           git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -277,21 +277,18 @@
         "@semantic-release/npm",
         {
           "npmPublish": false,
-          "tarballDir": "dist"
+          "tarballDir": "build"
         }
       ],
-      [
-        "@semantic-release/github",
-        {
-          "assets": [
-            {
-              "path": "build/ipfs-webui_*.car",
-              "name": "ipfs-webui@${nextRelease.gitTag}.car",
-              "label": "IPFS webui (${nextRelease.gitTag}) CAR file"
-            }
-          ]
-        }
-      ],
+      ["@semantic-release/github", {
+        "assets": [
+          {
+            "path": "ipfs-webui_*.car",
+            "name": "ipfs-webui@${nextRelease.gitTag}.car",
+            "label": "IPFS webui (${nextRelease.gitTag}) CAR file"
+          }
+        ]
+      }],
       "@semantic-release/git"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "ipfs-webui",
   "version": "2.17.3",
   "private": true,
+  "files": [
+    "src",
+    "public",
+    "@types",
+    "ipfs-core-types",
+    "docs",
+    "build"
+  ],
   "scripts": {
     "start": "run-script-os",
     "start:win32": "@powershell -Command $env:REACT_APP_GIT_REV=(git rev-parse --short HEAD); react-scripts start",

--- a/package.json
+++ b/package.json
@@ -277,7 +277,7 @@
         "@semantic-release/npm",
         {
           "npmPublish": false,
-          "tarballDir": "build"
+          "tarballDir": "dist"
         }
       ],
       ["@semantic-release/github", {


### PR DESCRIPTION
After enabling automated releases for this repo, I noticed a number of issues:

1. The car file was not attached to the GitHub release notes
2. Releases are generated for every single commit, causing release notes to become useless. We should batch commits and release only after a minimum wait time 
   * I'm going to revert to creating a release manually, except all that will be required is running https://github.com/ipfs/ipfs-webui/actions/workflows/ci.yml (i.e. `workflow_dispatch`). This is still a significant improvement upon the previous manual process
3. Even though semantic-release doesn't publish to npm currently (we have it disabled), the files being added to the npm tarball were unnecessary (.cache/*, and many others. You can see this on old runs). This was making the logs extremely difficult even to scroll through.
   * Specifying `"files":` in the package.json allows us to limit which files are included.
5. PRs weren't testing the 'semantic-release' part of the `ci.yml` workflow, so everything in the ci.yml workflow could go great, and then fail during semantic-release job.
   * Now, semantic-release is run with a dry-run flag for PRs

Also, see https://github.com/ipfs/ipfs-webui/issues/1970

This PR attempts to resolve all of the above issues.