### PR TITLE
fix: korean detection

### DIFF
--- a/src/i18n.js
+++ b/src/i18n.js
@@ -39,6 +39,7 @@ i18n
       'zh-Hans': ['zh-CN', 'en'],
       'zh-Hant': ['zh-TW', 'en'],
       zh: ['zh-CN', 'en'],
+      ko: ['ko-KR', 'en'],
       default: ['en']
     },
     debug: process.env.DEBUG,


### PR DESCRIPTION
This should fix #1999. I just wonder if this is not something that happens in other languages too. For example pt -> PT-PT or pt -> PT-BR.