### PR TITLE
fix: show '0 B' instead of '-' for zero-length files

### DIFF
--- a/src/files/file/File.js
+++ b/src/files/file/File.js
@@ -95,7 +95,7 @@ const File = ({
     styles.borderTop = '1px solid #eee'
   }
 
-  size = size ? humanSize(size, { round: 0 }) : '-'
+  size = humanSize(size, { round: 0 })
   const hash = cid.toString() || t('hashUnavailable')
 
   const select = (select) => onSelect(name, select)

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -173,7 +173,7 @@ export async function getCarLink (files, gatewayUrl, ipfs) {
  * @returns {string} human-readable size
  */
 export function humanSize (size, opts) {
-  if (typeof size === 'undefined') return 'N/A'
+  if (typeof size === 'undefined' || size === null) return 'N/A'
   return filesize(size || 0, {
     // base-2 byte units (GiB, MiB, KiB) to remove any ambiguity
     spacer: String.fromCharCode(160), // non-breakable space (&nbsp)


### PR DESCRIPTION
fixes #2017.

please check https://github.com/ipfs/ipfs-webui/issues/2017#issuecomment-1235417557 for more context

`humanSize` already takes care of undefined. I added a case for null.