### PR TITLE
feat: add Web3.Storage default pinning provider

### DIFF
--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -29,6 +29,12 @@ const pinningServiceTemplates = [
     icon: 'https://dweb.link/ipfs/QmWBaeu6y1zEcKbsEqCuhuDHPL3W8pZouCPdafMCRCSUWk?filename=filebase.png',
     apiEndpoint: 'https://api.filebase.io/v1/ipfs',
     visitServiceUrl: 'https://docs.filebase.com/api-documentation/ipfs-pinning-service-api'
+  },
+  {
+    name: 'Web3.Storage',
+    icon: 'https://bafybeiaqsdwuwemchbofzok4cq7cuvotfs6bgickxdqr6f7hdt7a64cwwa.ipfs.w3s.link/Web3.Storage-logo.svg',
+    apiEndpoint: 'https://api.web3.storage/pins',
+    visitServiceUrl: 'https://web3.storage/docs/how-tos/pinning-services-api/'
   }
 ].map((service) => {
   const domain = new URL(service.apiEndpoint).hostname


### PR DESCRIPTION
Part of https://github.com/ipfs/ipfs-webui/issues/2004

Note that for the image, I took the SVG directly from your website (class `site-logo-image`), saved as SVG, uploaded to web3.storage, and then grabbed the first link it pointed me to. @dchoi27 if you want me to use a different logo (one your team has control over ideally) or docs URL.

![image](https://user-images.githubusercontent.com/1173416/190012580-c362b7bf-5421-4739-90a8-c2e581107501.png)
