### PR TITLE
fix(settings): randomize pinning service templates

### DIFF
--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -2,6 +2,8 @@
 // This is a list of predefined templates for popular services from the IPFS
 // community.  We are open to reviewing PRs that add more entries here,
 // but only well-established and mission-aligned services will be accepted.
+// Services listed here are returned in a random order to ensure UI does not
+// promote any of them more than others.
 
 const complianceReportsHomepage = 'https://ipfs-shipyard.github.io/pinning-service-compliance'
 
@@ -47,7 +49,7 @@ const pinningServiceTemplates = [
   const domain = new URL(service.apiEndpoint).hostname
   service.complianceReportUrl = `${complianceReportsHomepage}/${domain}.html`
   return service
-})
+}).map(service => ({ service, sort: Math.random() })).sort((a, b) => a.sort - b.sort).map(({ service }) => service)
 
 export {
   complianceReportsHomepage,

--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -35,13 +35,13 @@ const pinningServiceTemplates = [
   {
     name: 'Web3.Storage',
     icon: 'https://dweb.link/ipfs/bafybeiaqsdwuwemchbofzok4cq7cuvotfs6bgickxdqr6f7hdt7a64cwwa/Web3.Storage-logo.svg',
-    apiEndpoint: 'https://api.web3.storage/pins',
+    apiEndpoint: 'https://api.web3.storage',
     visitServiceUrl: 'https://web3.storage/docs/how-tos/pinning-services-api/'
   },
   {
     name: 'Estuary',
     icon: 'https://dweb.link/ipfs/bafkreicn36fjx2tlanzslpayomdhgerh7oovlaasfkg7ltzgztf7a3buu4?filename=Estuary-logo.svg',
-    apiEndpoint: 'https://api.estuary.tech/pinning/pins',
+    apiEndpoint: 'https://api.estuary.tech/pinning',
     visitServiceUrl: 'https://docs.estuary.tech/tutorial-get-an-api-key'
   }
 


### PR DESCRIPTION
Now that we have 4+ services (https://github.com/ipfs/ipfs-webui/pull/2026) we should always show them in random order, so we do not promote any specific one above others.

This PR:
-  adds a simple shuffle that ensures random order across app loads
- fixes `service endpoint should be provided without the /pins suffix` error for templates added in #2026