### PR TITLE
ci: made the kubo version param CI workflow uses configurable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
           name: ipfs-webui_${{ github.sha }}.car
 
       - name: Dry-run semantic release
-        if: github.ref != 'refs/heads/main' || github.event.inputs.kubo-version
+        if: github.ref != 'refs/heads/main' && !github.event.inputs.kubo-version
         run: |
           git config user.name "ipfs-gui-bot"
           git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,6 @@ jobs:
       - uses: ipfs/download-ipfs-distribution-action@v1
         with:
           name: ipfs-cluster-ctl
-          version: ${{ github.event.inputs.ipfs-cluster-ctl-version }}
       - name: Fix DNS resolver
         run: |
           # fix resolv - DNS provided by Github is unreliable for DNSLik/dnsaddr

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
       kubo-version:
         description: Kubo version to use during the run
         required: false
-      ipfs-cluster-ctl-version:
-        description: IPFS Cluster CTL version to use during the run
-        required: false
   push:
     branches:
       - main
@@ -145,13 +142,13 @@ jobs:
 
       # dev dnslink is updated on each main branch update
       - run: npx dnslink-dnsimple --domain dev.webui.ipfs.io --link /ipfs/${{ steps.ipfs.outputs.cid }}
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && !github.event.inputs.kubo-version
         env:
           DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
 
       # production dnslink is updated on release (during tag build)
       - run: npx dnslink-dnsimple --domain webui.ipfs.io --link /ipfs/${{ steps.ipfs.outputs.cid }}
-        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && !github.event.inputs.kubo-version
         env:
           DNSIMPLE_TOKEN: ${{ secrets.DNSIMPLE_TOKEN }}
 
@@ -230,7 +227,7 @@ jobs:
           name: ipfs-webui_${{ github.sha }}.car
 
       - name: Dry-run semantic release
-        if: github.ref != 'refs/heads/main'
+        if: github.ref != 'refs/heads/main' || github.event.inputs.kubo-version
         run: |
           git config user.name "ipfs-gui-bot"
           git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"
@@ -240,7 +237,7 @@ jobs:
 
       # Update the version (npm version [major|minor|patch])
       - name: Run semantic release
-        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch'
+        if: github.ref == 'refs/heads/main' && github.event_name == 'workflow_dispatch' && !github.event.inputs.kubo-version
         run: |
           git config user.name "ipfs-gui-bot"
           git config user.email "108953096+ipfs-gui-bot@users.noreply.github.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: ci
 on:
   workflow_dispatch:
+    inputs:
+      kubo-version:
+        description: Kubo version to use during the run
+        required: false
+      ipfs-cluster-ctl-version:
+        description: IPFS Cluster CTL version to use during the run
+        required: false
   push:
     branches:
       - main
@@ -61,9 +68,11 @@ jobs:
       - uses: ipfs/download-ipfs-distribution-action@v1
         with:
           name: kubo
+          version: ${{ github.event.inputs.kubo-version }}
       - uses: ipfs/download-ipfs-distribution-action@v1
         with:
           name: ipfs-cluster-ctl
+          version: ${{ github.event.inputs.ipfs-cluster-ctl-version }}
       - name: Fix DNS resolver
         run: |
           # fix resolv - DNS provided by Github is unreliable for DNSLik/dnsaddr


### PR DESCRIPTION
I propose to make kubo version used during CI workflow run configurable.

This would enable running the CI workflow for a specific kubo release. In particular, we could include a testing step in the release checklist that asks the release lead to kick off CI workflow in `ipfs-webui` to test if the new kubo release is OK.

###### Testing
- https://github.com/ipfs/ipfs-webui/actions/runs/3135588411

_This is related to https://github.com/ipfs/kubo/issues/9237_