### PR TITLE
chore: replace topojson with topojson-client

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "redux-bundler": "^26.1.0",
     "redux-bundler-react": "^1.2.0",
     "tachyons": "^4.12.0",
-    "topojson": "^3.0.2",
+    "topojson-client": "^3.1.0",
     "uint8arrays": "2.1.2",
     "window-or-global": "^1.0.1"
   },

--- a/src/peers/WorldMap/Map.js
+++ b/src/peers/WorldMap/Map.js
@@ -1,5 +1,5 @@
 import * as d3 from 'd3'
-import * as topojson from 'topojson'
+import * as topojson from 'topojson-client'
 import ReactFauxDOM from 'react-faux-dom'
 import worldData from './world.json'
 


### PR DESCRIPTION
`topojson` has been deprecated in favor of other packages
![image](https://user-images.githubusercontent.com/1173416/192661309-66d6beb8-0d6a-4bb7-b2a4-20d691633a7c.png)

`topojson-client` is recommended for the two methods we were using: https://www.npmjs.com/package/topojson#manipulation-topojson-client

works 
![image](https://user-images.githubusercontent.com/1173416/192661189-87159bc0-443a-4b7a-a608-b9df2b34a4ba.png)

