### PR TITLE
fix: add missing devDependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsx-a11y": "^6.6.0",
     "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-n": "^15.3.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-storybook": "^0.6.1",


### PR DESCRIPTION
Dep eslint-plugin-n is required for yarn start or build, missing this will lead errors. and also eslint-plugin-node should be removed if all test passed, cause eslint-plugin-n is updated eslint-plugin-node