### PR TITLE
feat: Auto-Pulling translations

### DIFF
--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
     - name: Install Transifex client
       run: |
         curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
@@ -25,7 +27,7 @@ jobs:
         # Optional. Local and remote branch name where commit is going to be pushed
         #  to. Defaults to the current branch.
         #  You might need to set `create_branch: true` if the branch does not exist.
-        branch: i18n-sync
+        branch: main
 
         # Optional. Options used by `git-commit`.
         # See https://git-scm.com/docs/git-commit#_options
@@ -46,33 +48,10 @@ jobs:
         # See https://git-scm.com/docs/git-add#_options
         add_options: '-A'
 
-        # Optional. Options used by `git-push`.
-        # See https://git-scm.com/docs/git-push#_options
-        push_options: '--force'
-
         # Optional. Disable dirty check and always try to create a commit and push
-        skip_dirty_check: true
+        skip_dirty_check: false
 
-        # Optional. Skip internal call to `git fetch`
-        skip_fetch: true
-
-        # Optional. Skip internal call to `git checkout`
-        skip_checkout: true
 
         # Optional. Prevents the shell from expanding filenames.
         # Details: https://www.gnu.org/software/bash/manual/html_node/Filename-Expansion.html
         disable_globbing: true
-
-        # Optional. Create given branch name in local and remote repository.
-        create_branch: true
-    - name: pull-request
-      uses: repo-sync/pull-request@65785d95a5a466e46a9d0708933a3bd51bbf9dde
-      with:
-        source_branch: "i18n-sync"
-        destination_branch: "main"
-        pr_title: "chore: pull new translations"
-        pr_body: "Automated PR created by .github/workflows/tx-pull.yml"
-        pr_label: "area/i18n/translations"
-        pr_draft: false
-        pr_allow_empty: false
-        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -17,7 +17,7 @@ jobs:
         chmod +x ./tx
     - name: Pull translations from Transifex
       run: |
-        ./tx -t ${{ secrets.TX_TOKEN }} pull -a -f
+        ./tx -t ${{ secrets.TX_TOKEN }} pull -a -t -f
     - uses: stefanzweifel/git-auto-commit-action@49620cd3ed21ee620a48530e81dba0d139c9cb80
       with:
         # Optional. Commit message for the created commit.


### PR DESCRIPTION
Issue: #2029 

In this PR:
- Removed the PR creation step as we can instead directly commit on the `main`.
- This approach was chosen because otherwise, we need to create a PR and then merge it which is not as straightforward as this.
- Also, the workflow broke recently: https://github.com/ipfs/ipfs-webui/actions/runs/3257699721
  - Looks like there is an issue reported: https://github.com/transifex/cli/pull/107
  - However this conflicts with their documentation.
  - Adding that flag explicitly.