### PR TITLE
fix: support /quic-v1

### DIFF
--- a/patches/multiaddr+8.1.2.patch
+++ b/patches/multiaddr+8.1.2.patch
@@ -19,13 +19,14 @@ index 7258b50..09f28f9 100644
  
      case 421: // ipfs
 diff --git a/node_modules/multiaddr/src/protocols-table.js b/node_modules/multiaddr/src/protocols-table.js
-index 4578e43..840f7b2 100644
+index 4578e43..db46337 100644
 --- a/node_modules/multiaddr/src/protocols-table.js
 +++ b/node_modules/multiaddr/src/protocols-table.js
-@@ -52,6 +52,8 @@ Protocols.table = [
+@@ -52,6 +52,9 @@ Protocols.table = [
    [445, 296, 'onion3'],
    [446, V, 'garlic64'],
    [460, 0, 'quic'],
++  [461, 0, 'quic-v1'],
 +  [465, 0, 'webtransport'],
 +  [466, V, 'certhash'],
    [477, 0, 'ws'],


### PR DESCRIPTION
Kubo 0.18  (https://github.com/ipfs/kubo/issues/9417) will automatically listen on both `/quic` and new `/quic-v1`
Without this fix Status page would fail like https://github.com/ipfs/ipfs-webui/issues/2033

Ref. https://github.com/ipfs/kubo/issues/9410