### PR TITLE
fix: webui update metrics to opt-out by default (part of 2074)

### DIFF
--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -14,7 +14,7 @@
   },
   "customApiConfig": "Custom JSON configuration",
   "AskToEnable": {
-    "label": "Help improve this app by sending anonymous usage data."
+    "label": "We have recently updated our telemetry policy to switch to opt-out metrics. You previously had telemetry collection disabled. You can disable telemetry collection (again) on the settings page.",
   },
   "tour": {
     "step1": {

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -14,7 +14,7 @@
   },
   "customApiConfig": "Custom JSON configuration",
   "AskToEnable": {
-    "label": "We have recently updated our telemetry policy to switch to opt-out metrics. You previously had telemetry collection disabled. You can disable telemetry collection (again) on the settings page.",
+    "label": "We have recently updated our telemetry policy to switch to opt-out metrics. You previously had telemetry collection disabled. You can disable telemetry collection (again) on the settings page."
   },
   "tour": {
     "step1": {

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -13,7 +13,7 @@
     "peersCount": "{peersCount, plural, one {Discovered 1 peer} other {Discovered {peersCount} peers}}"
   },
   "customApiConfig": "Custom JSON configuration",
-  "AskToEnable": {
+  "AnalyticsBanner": {
     "label": "We have recently updated our telemetry policy to switch to opt-out metrics. You previously had telemetry collection disabled. You can disable telemetry collection (again) on the settings page."
   },
   "tour": {

--- a/src/App.js
+++ b/src/App.js
@@ -28,13 +28,11 @@ export class App extends Component {
     routeInfo: PropTypes.object.isRequired,
     filesPathInfo: PropTypes.object,
     // Injected by DropTarget
-    isOver: PropTypes.bool.isRequired,
-    doEnableAnalytics: PropTypes.object.isRequired
+    isOver: PropTypes.bool.isRequired
   }
 
   componentDidMount () {
     this.props.doTryInitIpfs()
-    this.props.doEnableAnalytics()
   }
 
   addFiles = async (filesPromise) => {
@@ -135,6 +133,5 @@ export default connect(
   'doFilesWrite',
   'doDisableTooltip',
   'selectFilesPathInfo',
-  'doEnableAnalytics',
   withTranslation('app')(AppWithDropTarget)
 )

--- a/src/App.js
+++ b/src/App.js
@@ -28,11 +28,13 @@ export class App extends Component {
     routeInfo: PropTypes.object.isRequired,
     filesPathInfo: PropTypes.object,
     // Injected by DropTarget
-    isOver: PropTypes.bool.isRequired
+    isOver: PropTypes.bool.isRequired,
+    doEnableAnalytics: PropTypes.object.isRequired
   }
 
   componentDidMount () {
     this.props.doTryInitIpfs()
+    this.props.doEnableAnalytics()
   }
 
   addFiles = async (filesPromise) => {
@@ -133,5 +135,6 @@ export default connect(
   'doFilesWrite',
   'doDisableTooltip',
   'selectFilesPathInfo',
+  'doEnableAnalytics',
   withTranslation('app')(AppWithDropTarget)
 )

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -49,16 +49,20 @@ import { ACTIONS as EXP } from './experiments'
  * @property {'ANALYTICS_ADD_CONSENT'} type
  * @property {{name:string}} payload
  *
+ * @typedef {Object} ToggleAskToEnable
+ * @property {'ANALYTICS_ASK_TO_ENABLE'} type
+ * @property {{shouldAsk:boolean?}} payload
+ *
  * @typedef {ExperimentsToggle|DesktopSettingToggle} Toggle
  * @typedef {MakeDir|Write|AddByPath|Move|Delete|DownloadLink} FilesMessage
- * @typedef {AnalyticsEnabled|AnalyticsDisabled|RemoveConsent|AddConsent} AnalyticsMessage
+ * @typedef {AnalyticsEnabled|AnalyticsDisabled|RemoveConsent|AddConsent|ToggleAskToEnable} AnalyticsMessage
  * @typedef {Init|ConfigSave|Toggle|FilesMessage|AnalyticsMessage} Message
  *
  * @typedef {Object} Model
  * @property {number} lastEnabledAt
  * @property {number} lastDisabledAt
  * @property {string[]} consent
- * @property {boolean} showAskToEnable
+ * @property {boolean?} showAskToEnable
  *
  * @typedef {Object} State
  * @property {Model} analytics
@@ -74,7 +78,7 @@ const ACTIONS = Enum.from([
   'ANALYTICS_DISABLED',
   'ANALYTICS_ADD_CONSENT',
   'ANALYTICS_REMOVE_CONSENT',
-  'ANALYTICS_ASK_TO_ENDABLE'
+  'ANALYTICS_ASK_TO_ENABLE'
 ])
 
 // Only record specific actions listed here.
@@ -263,8 +267,8 @@ const actions = {
    * @param {boolean?} shouldAsk
    * @returns {function(Context):void}
    */
-  doToggleAskToEnable: (shouldAsk) => ({ dispatch, store }) => {
-    dispatch({ type: 'ANALYTICS_ASK_TO_ENDABLE', payload: { shouldAsk } })
+  doToggleAskToEnable: (shouldAsk) => ({ dispatch }) => {
+    dispatch({ type: 'ANALYTICS_ASK_TO_ENABLE', payload: { shouldAsk } })
   }
 }
 
@@ -285,7 +289,7 @@ const createAnalyticsBundle = ({
       ACTIONS.ANALYTICS_DISABLED,
       ACTIONS.ANALYTICS_ADD_CONSENT,
       ACTIONS.ANALYTICS_REMOVE_CONSENT,
-      ACTIONS.ANALYTICS_ASK_TO_ENDABLE
+      ACTIONS.ANALYTICS_ASK_TO_ENABLE
     ],
 
     /**
@@ -404,7 +408,7 @@ const createAnalyticsBundle = ({
           const lastDisabledAt = (consent.length === 0) ? Date.now() : state.lastDisabledAt
           return { ...state, lastDisabledAt, consent }
         }
-        case ACTIONS.ANALYTICS_ASK_TO_ENDABLE: {
+        case ACTIONS.ANALYTICS_ASK_TO_ENABLE: {
           const showAskToEnableBanner = action.payload?.shouldAsk || false
           return { ...state, showAskToEnable: showAskToEnableBanner }
         }

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -175,7 +175,6 @@ const selectors = {
       return true
     }
 
-    // user has already made an explicit choice; dont ask again.
     return false
   },
 
@@ -330,8 +329,7 @@ const createAnalyticsBundle = ({
         const consent = store.selectAnalyticsConsent()
         addConsent(consent, store)
       } else if (store.selectAnalyticsInitialConsent()) {
-        // add consent/opt in by default if user previously opted out
-        // or if user previously had made no decision
+        // add consent/opt in by default
         store.doEnableAnalytics()
       }
 

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -149,6 +149,10 @@ const selectors = {
    */
   selectAnalyticsEnabled: (state) => state.analytics.consent.length > 0,
   /**
+   * @param {State} state
+   */
+  selectAnalyticsConsentDisabled: (state) => state.analytics.lastDisabledAt && state.analytics.consent.length === 0,
+  /**
    * Ask the user if we may enable analytics.
    * @param {State} state
    */
@@ -314,6 +318,9 @@ const createAnalyticsBundle = ({
       if (store.selectAnalyticsEnabled()) {
         const consent = store.selectAnalyticsConsent()
         addConsent(consent, store)
+      } else if (store.selectAnalyticsConsentDisabled()) {
+        // add consent by default for previous users who may have opted out
+        addConsent(consentGroups.safe, store)
       }
 
       store.subscribeToSelectors(['selectRouteInfo'], ({ routeInfo }) => {

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -153,12 +153,12 @@ const selectors = {
    * @param {State} state
    */
   selectAnalyticsAskToEnable: (state) => {
-    const { lastEnabledAt, lastDisabledAt, consent } = state.analytics
-    // user has not explicitly chosen
-    if (!lastEnabledAt && !lastDisabledAt && consent.length === 0) {
-      // ask to enable.
+    const { lastDisabledAt, consent } = state.analytics
+    // user has previously opted out of all and should be warned necessary analytics are now opt-out by default
+    if (lastDisabledAt && consent.length === 0) {
       return true
     }
+
     // user has already made an explicit choice; dont ask again.
     return false
   },

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -397,17 +397,18 @@ const createAnalyticsBundle = ({
 
       switch (action.type) {
         case ACTIONS.ANALYTICS_ENABLED:
-          return { ...state, lastEnabledAt: 0, consent: action.payload.consent, optedOut: false }
+          return { ...state, lastEnabledAt: Date.now(), consent: action.payload.consent, optedOut: false }
         case ACTIONS.ANALYTICS_DISABLED:
-          return { ...state, lastDisabledAt: 0, consent: action.payload.consent, optedOut: true, showAnalyticsBanner: false }
+          return { ...state, lastDisabledAt: Date.now(), consent: action.payload.consent, optedOut: true, showAnalyticsBanner: false }
         case ACTIONS.ANALYTICS_ADD_CONSENT: {
           const consent = state.consent.filter(item => item !== action.payload.name).concat(action.payload.name)
-          return { ...state, lastEnabledAt: 0, consent, optedOut: false }
+          return { ...state, lastEnabledAt: Date.now(), consent, optedOut: false }
         }
         case ACTIONS.ANALYTICS_REMOVE_CONSENT: {
           const consent = state.consent.filter(item => item !== action.payload.name)
+          const lastDisabledAt = (consent.length === 0) ? Date.now() : state.lastDisabledAt
           const didOptOutCompletely = consent.length === 0
-          return { ...state, lastDisabledAt: 0, lastEnabledAt: 0, consent, optedOut: didOptOutCompletely, showAnalyticsBanner: false }
+          return { ...state, lastDisabledAt, consent, optedOut: didOptOutCompletely, showAnalyticsBanner: false }
         }
         case ACTIONS.SET_SHOW_ANALYTICS_BANNER: {
           const shouldShowAnalyticsBanner = action.payload?.shouldShow || false

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -158,7 +158,7 @@ const selectors = {
   /**
    * @param {State} state
    */
-  selectAnalyticsOptedOutPriorToDefaultOptIn: (state) => state.analytics.consent.length === 0 && state.analytics.lastDisabledAt > state.analytics.lastEnabledAt,
+  selectAnalyticsOptedOutPriorToDefaultOptIn: (state) => !state.analytics.optedOut && state.analytics.consent.length === 0 && state.analytics.lastDisabledAt > state.analytics.lastEnabledAt,
   /**
    * @param {State} state
    */
@@ -397,18 +397,17 @@ const createAnalyticsBundle = ({
 
       switch (action.type) {
         case ACTIONS.ANALYTICS_ENABLED:
-          return { ...state, lastEnabledAt: Date.now(), consent: action.payload.consent, optedOut: false }
+          return { ...state, lastEnabledAt: 0, consent: action.payload.consent, optedOut: false }
         case ACTIONS.ANALYTICS_DISABLED:
-          return { ...state, lastDisabledAt: Date.now(), consent: action.payload.consent, optedOut: true, showAnalyticsBanner: false }
+          return { ...state, lastDisabledAt: 0, consent: action.payload.consent, optedOut: true, showAnalyticsBanner: false }
         case ACTIONS.ANALYTICS_ADD_CONSENT: {
           const consent = state.consent.filter(item => item !== action.payload.name).concat(action.payload.name)
-          return { ...state, lastEnabledAt: Date.now(), consent, optedOut: false }
+          return { ...state, lastEnabledAt: 0, consent, optedOut: false }
         }
         case ACTIONS.ANALYTICS_REMOVE_CONSENT: {
           const consent = state.consent.filter(item => item !== action.payload.name)
-          const lastDisabledAt = (consent.length === 0) ? Date.now() : state.lastDisabledAt
           const didOptOutCompletely = consent.length === 0
-          return { ...state, lastDisabledAt, consent, optedOut: didOptOutCompletely, showAnalyticsBanner: false }
+          return { ...state, lastDisabledAt: 0, lastEnabledAt: 0, consent, optedOut: didOptOutCompletely, showAnalyticsBanner: false }
         }
         case ACTIONS.SET_SHOW_ANALYTICS_BANNER: {
           const shouldShowAnalyticsBanner = action.payload?.shouldShow || false

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -73,7 +73,16 @@ describe('new/returning user default behavior', () => {
   })
 
   it('should hide analytics banner if user has closed the banner', () => {
-    const store = createStore()
+    const mockDefaultState = {
+      lastEnabledAt: 0,
+      lastDisabledAt: Date.now(),
+      showAnalyticsBanner: false,
+      optedOut: false,
+      consent: []
+    }
+    const store = createStore({}, mockDefaultState)
+    expect(store.selectShowAnalyticsBanner()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
     store.doToggleShowAnalyticsBanner(false)
     expect(store.selectShowAnalyticsBanner()).toBe(false)
   })
@@ -131,6 +140,7 @@ describe('user manages all analytics consent with settings page toggle', () => {
       optedOut: true
     }
     const store = createStore({}, mockDefaultState)
+    expect(store.selectAnalyticsEnabled()).toBe(false)
     store.doToggleAnalytics()
     expect(store.selectAnalyticsEnabled()).toBe(true)
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
@@ -142,7 +152,7 @@ describe('user manages all analytics consent with settings page toggle', () => {
 })
 
 describe('user manages analytics consent with individual settings toggles', () => {
-  it('should toggle on crashes consent', () => {
+  it('should toggle consent on for "crashes"', () => {
     const mockDefaultState = {
       lastEnabledAt: Date.now,
       lastDisabledAt: 1674166495717, // past
@@ -154,7 +164,7 @@ describe('user manages analytics consent with individual settings toggles', () =
     expect(store.selectAnalyticsEnabled()).toBe(true)
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location', 'crashes'])
   })
-  it('should toggle off one (sessions) consent', () => {
+  it('should toggle consent off for one ("sessions")', () => {
     const mockDefaultState = {
       lastEnabledAt: Date.now,
       lastDisabledAt: 1674166495717, // past
@@ -166,7 +176,7 @@ describe('user manages analytics consent with individual settings toggles', () =
     expect(store.selectAnalyticsEnabled()).toBe(true)
     expect(store.selectAnalyticsConsent()).toEqual(['events', 'views', 'location'])
   })
-  it('should opt_out if toggle off all individual consent', () => {
+  it('should opt_out if consent is toggled off for all existing consents', () => {
     const mockDefaultState = {
       lastEnabledAt: Date.now,
       lastDisabledAt: 1674166495717, // past

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -33,7 +33,6 @@ function createStore (analyticsOpts = {}, mockAnalyticsCachedState) {
   })
 }
 
-it('should render', () => {})
 describe('new/returning user default behavior', () => {
   it('should enable analytics by default for new user who has not opted in or out', () => {
     const store = createStore()

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -1,4 +1,4 @@
-/* global it, expect, beforeEach, afterEach, jest */
+/* global describe, it, expect, beforeEach, afterEach, jest */
 import { composeBundlesRaw } from 'redux-bundler'
 import createAnalyticsBundle from './analytics'
 
@@ -15,7 +15,7 @@ afterEach(() => {
   delete global.Countly
 })
 
-function createStore (analyticsOpts = {}) {
+function createStore (analyticsOpts = {}, mockAnalyticsCachedState) {
   return composeBundlesRaw(
     {
       name: 'mockRoutesBundle',
@@ -27,163 +27,162 @@ function createStore (analyticsOpts = {}) {
       selectDesktopCountlyActions: () => ([])
     },
     createAnalyticsBundle(analyticsOpts)
-  )()
+  )({
+    // tests using mockAnalyticsCachedState are mimicking the createCacheBundle that sets initial state
+    analytics: mockAnalyticsCachedState
+  })
 }
 
-it('should enable analytics by default', () => {
-  const store = createStore()
-  expect(store.selectAnalyticsEnabled() || store.selectAnalyticsInitialConsent()).toBe(true)
-  // user has not explicitly opted out yet
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
-  // events will be sent as consents have been given by default
-  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+it('should render', () => {})
+describe('new/returning user default behavior', () => {
+  it('should enable analytics by default for new user who has not opted in or out', () => {
+    const store = createStore()
+    expect(global.Countly.opt_in).toHaveBeenCalled()
+    expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+    // events will be sent as consents have been given by default
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+  })
+  it('should enable existing analytics by default for returning user who was opted_in', () => {
+    const mockDefaultState = {
+      lastEnabledAt: Date.now(),
+      lastDisabledAt: 0,
+      showAnalyticsBanner: false,
+      optedOut: false,
+      consent: ['sessions', 'events', 'views']
+    }
+    const store = createStore({}, mockDefaultState)
+    console.log(store.getState())
+    expect(store.selectAnalyticsEnabled()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views'])
+    // should not show analytics banner for these users
+    expect(store.selectShowAnalyticsBanner()).toBe(false)
+  })
+  it('should enable analytics for returning user who opted_out prior to new opt-in by default updates', () => {
+    const mockDefaultState = {
+      lastEnabledAt: 0,
+      lastDisabledAt: Date.now(),
+      showAnalyticsBanner: false,
+      optedOut: false,
+      consent: []
+    }
+    const store = createStore({}, mockDefaultState)
+    console.log(store.getState())
+    console.log('trueeee', mockDefaultState)
+    expect(global.Countly.opt_in).toHaveBeenCalled()
+    expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+    // should show analytics banner for these users
+    expect(store.selectShowAnalyticsBanner()).toBe(true)
+  })
+
+  it('should hide analytics banner if user has closed the banner', () => {
+    const store = createStore()
+    store.doToggleShowAnalyticsBanner(false)
+    expect(store.selectShowAnalyticsBanner()).toBe(false)
+  })
 })
 
-it('should enable analytics if user has explicitly enabled it', () => {
-  const store = createStore()
-  global.Countly.opt_in.mockClear()
-  store.doEnableAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+describe('user enables and disables analytics', () => {
+  it('should enable analytics if user who has opted out explicitly enables it', () => {
+    const mockDefaultState = {
+      lastEnabledAt: 0,
+      lastDisabledAt: Date.now(),
+      showAnalyticsBanner: false,
+      optedOut: true,
+      consent: []
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doEnableAnalytics()
+    expect(store.selectAnalyticsEnabled()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+    expect(global.Countly.opt_in).toHaveBeenCalled()
+    expect(global.Countly.opt_out).not.toHaveBeenCalled()
+    expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+  })
+
+  it('should disable analytics if user explicitly disables it', () => {
+    const store = createStore()
+    store.doDisableAnalytics()
+    expect(store.selectAnalyticsEnabled()).toBe(false)
+    expect(store.selectAnalyticsConsent()).toEqual([])
+    expect(global.Countly.opt_out).toHaveBeenCalled()
+    expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+  })
 })
 
-it('should disable analytics if user has explicitly disabled it', () => {
-  const store = createStore()
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-  store.doDisableAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(false)
-  expect(store.selectAnalyticsConsent()).toEqual([])
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).toHaveBeenCalled()
-  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+describe('user manages all analytics consent with settings page toggle', () => {
+  it('should toggle analytics consent off for user with consent enabled', () => {
+    const mockDefaultState = {
+      lastEnabledAt: Date.now(),
+      lastDisabledAt: 0,
+      consent: ['sessions', 'events', 'views'],
+      optedOut: false
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doToggleAnalytics()
+    expect(store.selectAnalyticsEnabled()).toBe(false)
+    expect(store.selectAnalyticsConsent()).toEqual([])
+    expect(global.Countly.opt_in).not.toHaveBeenCalled()
+    expect(global.Countly.opt_out).toHaveBeenCalled()
+    expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+  })
+  it('should toggle analytics consent on for user with consent disabled', () => {
+    const mockDefaultState = {
+      lastEnabledAt: 1674166495717, // past
+      lastDisabledAt: Date.now(),
+      consent: [],
+      optedOut: true
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doToggleAnalytics()
+    expect(store.selectAnalyticsEnabled()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+    expect(store.selectAnalyticsOptedOut()).toBe(false)
+    expect(global.Countly.opt_in).toHaveBeenCalled()
+    expect(global.Countly.opt_out).not.toHaveBeenCalled()
+    expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+  })
 })
 
-it('should disable selectAnalyticsAskToEnable if user has not explicity enabled or disabled it', () => {
-  const store = createStore()
-  expect(store.selectAnalyticsAskToEnable()).toBe(false)
-})
-
-it('should disable selectAnalyticsAskToEnable if user has explicity disabled it', () => {
-  const store = createStore()
-  global.Countly.opt_out.mockClear()
-  store.doDisableAnalytics()
-  expect(store.selectAnalyticsAskToEnable()).toBe(false)
-})
-
-it('should disable selectAnalyticsAskToEnable if user has explicity enabled it', () => {
-  const store = createStore()
-  global.Countly.opt_out.mockClear()
-  store.doEnableAnalytics()
-  expect(store.selectAnalyticsAskToEnable()).toBe(false)
-})
-
-it('should disable selectAnalyticsAskToEnable if analytics are enabled', () => {
-  const store = createStore()
-  global.Countly.opt_out.mockClear()
-  store.doEnableAnalytics()
-  expect(store.selectAnalyticsAskToEnable()).toBe(false)
-})
-
-it('should toggle analytics', () => {
-  const store = createStore()
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(false)
-  expect(store.selectAnalyticsConsent()).toEqual([])
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).toHaveBeenCalled()
-  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
-
-  // reset the mocks here to simplify the following assetions
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
-})
-
-it('should toggle consent', () => {
-  const store = createStore()
-  // reset to off from previous
-  store.doToggleAnalytics()
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-  store.doToggleConsent('crashes')
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['crashes'])
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
-  // reset the mocks here to simplify the following assetions
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(false)
-  expect(store.selectAnalyticsConsent()).toEqual([])
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).toHaveBeenCalled()
-  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleConsent('sessions')
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['events', 'views', 'location'])
-  // changing the consents should not opt/in or out
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  // reset the mocks here to simplify the following assetions
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleConsent('location')
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['events', 'views'])
-  // changing the consents should not opt/in or out
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  // reset the mocks here to simplify the following assetions
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  store.doToggleConsent('views')
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['events'])
-  // changing the consents should not opt/in or out
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  // reset the mocks here to simplify the following assetions
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
-
-  // Removing all consent is equivalent to disabling the analytics.
-  store.doToggleConsent('events')
-  expect(store.selectAnalyticsEnabled()).toBe(false)
-  expect(store.selectAnalyticsConsent()).toEqual([])
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).toHaveBeenCalled()
-  expect(global.Countly.opt_out.mock.calls.length).toBe(1)
-  global.Countly.opt_in.mockClear()
-  global.Countly.opt_out.mockClear()
+describe('user manages analytics consent with individual settings toggles', () => {
+  it('should toggle on crashes consent', () => {
+    const mockDefaultState = {
+      lastEnabledAt: Date.now,
+      lastDisabledAt: 1674166495717, // past
+      consent: ['sessions', 'events', 'views', 'location'],
+      optedOut: false
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doToggleConsent('crashes')
+    expect(store.selectAnalyticsEnabled()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location', 'crashes'])
+  })
+  it('should toggle off one (sessions) consent', () => {
+    const mockDefaultState = {
+      lastEnabledAt: Date.now,
+      lastDisabledAt: 1674166495717, // past
+      consent: ['sessions', 'events', 'views', 'location'],
+      optedOut: false
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doToggleConsent('sessions')
+    expect(store.selectAnalyticsEnabled()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual(['events', 'views', 'location'])
+  })
+  it('should opt_out if toggle off all individual consent', () => {
+    const mockDefaultState = {
+      lastEnabledAt: Date.now,
+      lastDisabledAt: 1674166495717, // past
+      consent: ['views', 'location'],
+      optedOut: false
+    }
+    const store = createStore({}, mockDefaultState)
+    store.doToggleConsent('views')
+    store.doToggleConsent('location')
+    expect(store.selectAnalyticsEnabled()).toBe(false)
+    expect(store.selectAnalyticsOptedOut()).toBe(true)
+    expect(store.selectAnalyticsConsent()).toEqual([])
+    expect(global.Countly.opt_out).toHaveBeenCalled()
+    expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+  })
 })

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -71,7 +71,6 @@ describe('new/returning user default behavior', () => {
     // should show analytics banner for these users
     expect(store.selectShowAnalyticsBanner()).toBe(true)
   })
-
   it('should hide analytics banner if user has closed the banner', () => {
     const mockDefaultState = {
       lastEnabledAt: 0,
@@ -85,6 +84,7 @@ describe('new/returning user default behavior', () => {
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
     store.doToggleShowAnalyticsBanner(false)
     expect(store.selectShowAnalyticsBanner()).toBe(false)
+    expect(store.selectAnalyticsOptedOutPriorToDefaultOptIn()).toBe(false)
   })
 })
 
@@ -128,6 +128,7 @@ describe('user manages all analytics consent with settings page toggle', () => {
     store.doToggleAnalytics()
     expect(store.selectAnalyticsEnabled()).toBe(false)
     expect(store.selectAnalyticsConsent()).toEqual([])
+    expect(store.selectAnalyticsOptedOut()).toBe(true)
     expect(global.Countly.opt_in).not.toHaveBeenCalled()
     expect(global.Countly.opt_out).toHaveBeenCalled()
     expect(global.Countly.opt_out.mock.calls.length).toBe(1)

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -30,18 +30,19 @@ function createStore (analyticsOpts = {}) {
   )()
 }
 
-it('should disable analytics by default', () => {
+it('should enable analytics by default', () => {
   const store = createStore()
-  expect(store.selectAnalyticsEnabled()).toBe(false)
-  // no events will be sent as no consents have been given
-  expect(store.selectAnalyticsConsent()).toEqual([])
-  // user has not explicitly opted in or out yet
-  expect(global.Countly.opt_in).not.toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(store.selectAnalyticsEnabled() || store.selectAnalyticsInitialConsent()).toBe(true)
+  // user has not explicitly opted out yet
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
+  // events will be sent as consents have been given by default
+  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
 })
 
 it('should enable analytics if user has explicitly enabled it', () => {
   const store = createStore()
+  global.Countly.opt_in.mockClear()
   store.doEnableAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
@@ -52,6 +53,8 @@ it('should enable analytics if user has explicitly enabled it', () => {
 
 it('should disable analytics if user has explicitly disabled it', () => {
   const store = createStore()
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
   store.doDisableAnalytics()
   expect(store.selectAnalyticsEnabled()).toBe(false)
   expect(store.selectAnalyticsConsent()).toEqual([])
@@ -60,40 +63,34 @@ it('should disable analytics if user has explicitly disabled it', () => {
   expect(global.Countly.opt_out.mock.calls.length).toBe(1)
 })
 
-it('should enable selectAnalyticsAskToEnable if user has not explicity enabled or disabled it', () => {
+it('should disable selectAnalyticsAskToEnable if user has not explicity enabled or disabled it', () => {
   const store = createStore()
-  expect(store.selectAnalyticsAskToEnable()).toBe(true)
+  expect(store.selectAnalyticsAskToEnable()).toBe(false)
 })
 
 it('should disable selectAnalyticsAskToEnable if user has explicity disabled it', () => {
   const store = createStore()
+  global.Countly.opt_out.mockClear()
   store.doDisableAnalytics()
   expect(store.selectAnalyticsAskToEnable()).toBe(false)
 })
 
 it('should disable selectAnalyticsAskToEnable if user has explicity enabled it', () => {
   const store = createStore()
+  global.Countly.opt_out.mockClear()
   store.doEnableAnalytics()
   expect(store.selectAnalyticsAskToEnable()).toBe(false)
 })
 
 it('should disable selectAnalyticsAskToEnable if analytics are enabled', () => {
   const store = createStore()
+  global.Countly.opt_out.mockClear()
   store.doEnableAnalytics()
   expect(store.selectAnalyticsAskToEnable()).toBe(false)
 })
 
 it('should toggle analytics', () => {
   const store = createStore()
-
-  store.doToggleAnalytics()
-  expect(store.selectAnalyticsEnabled()).toBe(true)
-  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
-  expect(global.Countly.opt_in).toHaveBeenCalled()
-  expect(global.Countly.opt_out).not.toHaveBeenCalled()
-  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
-
-  // reset the mocks here to simplify the following assetions
   global.Countly.opt_in.mockClear()
   global.Countly.opt_out.mockClear()
 
@@ -103,11 +100,25 @@ it('should toggle analytics', () => {
   expect(global.Countly.opt_in).not.toHaveBeenCalled()
   expect(global.Countly.opt_out).toHaveBeenCalled()
   expect(global.Countly.opt_out.mock.calls.length).toBe(1)
+
+  // reset the mocks here to simplify the following assetions
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
+
+  store.doToggleAnalytics()
+  expect(store.selectAnalyticsEnabled()).toBe(true)
+  expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
+  expect(global.Countly.opt_in).toHaveBeenCalled()
+  expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  expect(global.Countly.opt_in.mock.calls.length).toBe(1)
 })
 
 it('should toggle consent', () => {
   const store = createStore()
-
+  // reset to off from previous
+  store.doToggleAnalytics()
+  global.Countly.opt_in.mockClear()
+  global.Countly.opt_out.mockClear()
   store.doToggleConsent('crashes')
   expect(store.selectAnalyticsEnabled()).toBe(true)
   expect(store.selectAnalyticsConsent()).toEqual(['crashes'])

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -44,7 +44,7 @@ describe('new/returning user default behavior', () => {
   })
   it('should enable existing analytics by default for returning user who was opted_in', () => {
     const mockDefaultState = {
-      lastEnabledAt: Date.now(),
+      lastEnabledAt: (new Date('2022-01-02')).getTime(),
       lastDisabledAt: 0,
       showAnalyticsBanner: false,
       optedOut: false,
@@ -59,7 +59,7 @@ describe('new/returning user default behavior', () => {
   it('should enable analytics for returning user who opted_out prior to new opt-in by default updates', () => {
     const mockDefaultState = {
       lastEnabledAt: 0,
-      lastDisabledAt: Date.now(),
+      lastDisabledAt: (new Date('2022-01-02')).getTime(),
       showAnalyticsBanner: false,
       optedOut: false,
       consent: []
@@ -74,7 +74,7 @@ describe('new/returning user default behavior', () => {
   it('should hide analytics banner if user has closed the banner', () => {
     const mockDefaultState = {
       lastEnabledAt: 0,
-      lastDisabledAt: Date.now(),
+      lastDisabledAt: (new Date('2022-01-01')).getTime(),
       showAnalyticsBanner: false,
       optedOut: false,
       consent: []
@@ -92,7 +92,7 @@ describe('user enables and disables analytics', () => {
   it('should enable analytics if user who has opted out explicitly enables it', () => {
     const mockDefaultState = {
       lastEnabledAt: 0,
-      lastDisabledAt: Date.now(),
+      lastDisabledAt: (new Date('2022-01-01')).getTime(),
       showAnalyticsBanner: false,
       optedOut: true,
       consent: []
@@ -119,7 +119,7 @@ describe('user enables and disables analytics', () => {
 describe('user manages all analytics consent with settings page toggle', () => {
   it('should toggle analytics consent off for user with consent enabled', () => {
     const mockDefaultState = {
-      lastEnabledAt: Date.now(),
+      lastEnabledAt: (new Date('2022-01-02')).getTime(),
       lastDisabledAt: 0,
       consent: ['sessions', 'events', 'views'],
       optedOut: false
@@ -135,8 +135,8 @@ describe('user manages all analytics consent with settings page toggle', () => {
   })
   it('should toggle analytics consent on for user with consent disabled', () => {
     const mockDefaultState = {
-      lastEnabledAt: 1674166495717, // past
-      lastDisabledAt: Date.now(),
+      lastEnabledAt: (new Date('2022-01-01')).getTime(),
+      lastDisabledAt: (new Date('2022-01-02')).getTime(),
       consent: [],
       optedOut: true
     }
@@ -155,8 +155,8 @@ describe('user manages all analytics consent with settings page toggle', () => {
 describe('user manages analytics consent with individual settings toggles', () => {
   it('should toggle consent on for "crashes"', () => {
     const mockDefaultState = {
-      lastEnabledAt: Date.now,
-      lastDisabledAt: 1674166495717, // past
+      lastEnabledAt: (new Date('2022-01-02')).getTime(),
+      lastDisabledAt: (new Date('2022-01-01')).getTime(),
       consent: ['sessions', 'events', 'views', 'location'],
       optedOut: false
     }
@@ -167,8 +167,8 @@ describe('user manages analytics consent with individual settings toggles', () =
   })
   it('should toggle consent off for one ("sessions")', () => {
     const mockDefaultState = {
-      lastEnabledAt: Date.now,
-      lastDisabledAt: 1674166495717, // past
+      lastEnabledAt: (new Date('2022-01-02')).getTime(),
+      lastDisabledAt: (new Date('2022-01-01')).getTime(),
       consent: ['sessions', 'events', 'views', 'location'],
       optedOut: false
     }
@@ -179,8 +179,8 @@ describe('user manages analytics consent with individual settings toggles', () =
   })
   it('should opt_out if consent is toggled off for all existing consents', () => {
     const mockDefaultState = {
-      lastEnabledAt: Date.now,
-      lastDisabledAt: 1674166495717, // past
+      lastEnabledAt: (new Date('2022-01-02')).getTime(),
+      lastDisabledAt: (new Date('2022-01-01')).getTime(),
       consent: ['views', 'location'],
       optedOut: false
     }

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -51,7 +51,6 @@ describe('new/returning user default behavior', () => {
       consent: ['sessions', 'events', 'views']
     }
     const store = createStore({}, mockDefaultState)
-    console.log(store.getState())
     expect(store.selectAnalyticsEnabled()).toBe(true)
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views'])
     // should not show analytics banner for these users
@@ -66,8 +65,6 @@ describe('new/returning user default behavior', () => {
       consent: []
     }
     const store = createStore({}, mockDefaultState)
-    console.log(store.getState())
-    console.log('trueeee', mockDefaultState)
     expect(global.Countly.opt_in).toHaveBeenCalled()
     expect(global.Countly.opt_in.mock.calls.length).toBe(1)
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])

--- a/src/components/analytics-banner/AnalyticsBanner.js
+++ b/src/components/analytics-banner/AnalyticsBanner.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Button from '../button/Button'
 
-const AskToEnable = ({ className, label, yesLabel, onYes }) => {
+const AnalyticsBanner = ({ className, label, yesLabel, onYes }) => {
   return (
     <div className={`f6 pv3 pv2-ns ph3 tc bg-snow charcoal flex ${className}`}>
       <span className='fw4 lh-copy dib mb2 tl'>
@@ -14,4 +14,4 @@ const AskToEnable = ({ className, label, yesLabel, onYes }) => {
   )
 }
 
-export default AskToEnable
+export default AnalyticsBanner

--- a/src/components/ask/AskToEnable.js
+++ b/src/components/ask/AskToEnable.js
@@ -1,20 +1,14 @@
 import React from 'react'
 import Button from '../button/Button'
 
-const AskToEnable = ({ className, label, yesLabel, noLabel, onYes, onNo, detailsLabel = 'More info...', detailsLink }) => {
+const AskToEnable = ({ className, label, yesLabel, onYes }) => {
   return (
-    <div className={`f6 pv3 pv2-ns ph3 tc bg-snow charcoal ${className}`}>
-      <span className='fw4 lh-copy dib mb2'>
+    <div className={`f6 pv3 pv2-ns ph3 tc bg-snow charcoal flex ${className}`}>
+      <span className='fw4 lh-copy dib mb2 tl'>
         {label}
-        {detailsLink && (
-          <a href={detailsLink} className='dib focus-outline link blue ml2'>
-            {detailsLabel}
-          </a>
-        )}
       </span>
       <span className='dib'>
         <Button className='ml3 mv1 tc' bg={'bg-green'} onClick={onYes}>{yesLabel}</Button>
-        <Button className='ml3 mv1 tc' color='charcoal' bg={'bg-snow-muted'} onClick={onNo}>{noLabel}</Button>
       </span>
     </div>
   )

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -22,6 +22,7 @@ const StatusPage = ({
   analyticsAskToEnable,
   doEnableAnalytics,
   doDisableAnalytics,
+  doToggleAskToEnable,
   toursEnabled,
   handleJoyrideCallback,
   nodeBandwidthEnabled
@@ -57,7 +58,7 @@ const StatusPage = ({
           className='mt3'
           label={t('AskToEnable.label')}
           yesLabel={t('app:actions.close')}
-          onYes={doEnableAnalytics} />
+          onYes={() => doToggleAskToEnable(false)} />
       }
       <div style={{ opacity: ipfsConnected ? 1 : 0.4 }}>
         { nodeBandwidthEnabled
@@ -94,5 +95,6 @@ export default connect(
   'selectToursEnabled',
   'doEnableAnalytics',
   'doDisableAnalytics',
+  'doToggleAskToEnable',
   withTour(withTranslation('status')(StatusPage))
 )

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -11,7 +11,7 @@ import NodeInfoAdvanced from './NodeInfoAdvanced'
 import NodeBandwidthChart from './NodeBandwidthChart'
 import NetworkTraffic from './NetworkTraffic'
 import Box from '../components/box/Box'
-import AskToEnable from '../components/ask/AskToEnable'
+import AnalyticsBanner from '../components/analytics-banner/AnalyticsBanner'
 import { statusTour } from '../lib/tours'
 import { getJoyrideLocales } from '../helpers/i8n'
 import withTour from '../components/tour/withTour'
@@ -19,10 +19,10 @@ import withTour from '../components/tour/withTour'
 const StatusPage = ({
   t,
   ipfsConnected,
-  analyticsAskToEnable,
+  showAnalyticsBanner,
   doEnableAnalytics,
   doDisableAnalytics,
-  doToggleAskToEnable,
+  doToggleShowAnalyticsBanner,
   toursEnabled,
   handleJoyrideCallback,
   nodeBandwidthEnabled
@@ -53,12 +53,12 @@ const StatusPage = ({
           </div>
         </div>
       </Box>
-      { ipfsConnected && analyticsAskToEnable &&
-        <AskToEnable
+      { ipfsConnected && showAnalyticsBanner &&
+        <AnalyticsBanner
           className='mt3'
-          label={t('AskToEnable.label')}
+          label={t('AnalyticsBanner.label')}
           yesLabel={t('app:actions.close')}
-          onYes={() => doToggleAskToEnable(false)} />
+          onYes={() => doToggleShowAnalyticsBanner(false)} />
       }
       <div style={{ opacity: ipfsConnected ? 1 : 0.4 }}>
         { nodeBandwidthEnabled
@@ -91,10 +91,10 @@ const StatusPage = ({
 export default connect(
   'selectIpfsConnected',
   'selectNodeBandwidthEnabled',
-  'selectAnalyticsAskToEnable',
+  'selectShowAnalyticsBanner',
   'selectToursEnabled',
   'doEnableAnalytics',
   'doDisableAnalytics',
-  'doToggleAskToEnable',
+  'doToggleShowAnalyticsBanner',
   withTour(withTranslation('status')(StatusPage))
 )

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -56,12 +56,8 @@ const StatusPage = ({
         <AskToEnable
           className='mt3'
           label={t('AskToEnable.label')}
-          yesLabel={t('app:actions.ok')}
-          noLabel={t('app:actions.noThanks')}
-          detailsLabel={t('app:actions.moreInfo')}
-          detailsLink='#/settings/analytics'
-          onYes={doEnableAnalytics}
-          onNo={doDisableAnalytics} />
+          yesLabel={t('app:actions.close')}
+          onYes={doEnableAnalytics} />
       }
       <div style={{ opacity: ipfsConnected ? 1 : 0.4 }}>
         { nodeBandwidthEnabled


### PR DESCRIPTION
fixes: https://github.com/ipfs/ipfs-desktop/issues/2370
fixes: #2085 

- Updates  banner per discussion ([here](https://www.notion.so/pl-strflt/Metrics-Collection-and-Consent-Language-0d4059f11d4d474bb76d00539d778d8d#35482f9eef47464cb9efab8eaf7b4f8f)) and enables metrics on app load