### PR TITLE
test: only repeat e2e tests on PRs

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,7 +41,12 @@ jobs:
         run: npm run test:build
 
       - name: Run E2E against ${{ matrix.backend }}-ipfs
+        if: github.ref != 'refs/heads/main' # only run duplicated e2e tests on PRs
         run: E2E_IPFSD_TYPE=${{ matrix.backend }} npm run test:e2e -- --repeat-each 10 --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} # run each test 10 times to ensure no flakiness
+
+      - name: Run E2E against ${{ matrix.backend }}-ipfs
+        if: github.ref == 'refs/heads/main' # run non-duplicated tests on non-PRs
+        run: E2E_IPFSD_TYPE=${{ matrix.backend }} npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} # run each test 10 times to ensure no flakiness
 
       - name: Generate nyc coverage report
         id: coverage


### PR DESCRIPTION
This PR ensures playwright tests use the `--repeat-each 10` option only for
PRs.

We want to ensure we do not introduce flakiness without slowing down the rest of the CI jobs
