### PR TITLE
fix: dont spam IPFS_INIT_FAILED events to countly

### DIFF
--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -10,6 +10,7 @@ import { ACTIONS as CONIFG } from './config-save.js'
 import { ACTIONS as INIT } from './ipfs-provider.js'
 import { ACTIONS as EXP } from './experiments.js'
 import { getDeploymentEnv } from '../env.js'
+import { onlyOnceAfter } from '../lib/hofs/functions.js'
 
 /**
  * @typedef {import('./ipfs-provider').Init} Init
@@ -147,6 +148,28 @@ function removeConsent (consent, store) {
     store.doDesktopRemoveConsent(consent)
   }
 }
+
+/**
+ * Add an event to countly.
+ *
+ * @param {Object} param0
+ * @param {string} param0.id
+ * @param {number} param0.duration
+ */
+function addEvent ({ id, duration }) {
+  root.Countly.q.push(['add_event', {
+    key: id,
+    count: 1,
+    dur: duration
+  }])
+}
+
+/**
+ * You can limit how many times an event is recorded by adding them here.
+ */
+const addEventLimitedFns = new Map([
+  ['IPFS_INIT_FAILED', onlyOnceAfter(5, addEvent)]
+])
 
 /**
  * @typedef {import('redux-bundler').Selectors<typeof selectors>} Selectors
@@ -306,6 +329,7 @@ const createAnalyticsBundle = ({
      * @param {Store} store
      */
     init: async (store) => {
+      // LogRocket.init('sfqf1k/ipfs-webui')
       // test code sets a mock Counly instance on the global.
       if (!root.Countly) {
         root.Countly = {}
@@ -375,16 +399,19 @@ const createAnalyticsBundle = ({
         const payload = parseTask(action)
         if (payload) {
           const { id, duration, error } = payload
-          root.Countly.q.push(['add_event', {
-            key: id,
-            count: 1,
-            dur: duration
-          }])
+          const addEventFn = addEventLimitedFns.get(id)
+          if (addEventFn != null) {
+            addEventFn({ id, duration })
+          } else {
+            addEvent({ id, duration })
+          }
 
           // Record errors. Only from explicitly selected actions.
           if (error) {
             root.Countly.q.push(['add_log', action.type])
             root.Countly.q.push(['log_error', error])
+            // LogRocket.error(error)
+            // logger.error('Error in action', action.type, error)
           }
         }
 

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -172,6 +172,23 @@ const addEventLimitedFns = new Map([
 ])
 
 /**
+ * Add an event to by using a limited addEvent fn if one is defined, or calling
+ * `addEvent` directly.
+ *
+ * @param {Object} param0
+ * @param {string} param0.id
+ * @param {number} param0.duration
+ */
+function addEventWrapped ({ id, duration }) {
+  const fn = addEventLimitedFns.get(id)
+  if (fn) {
+    fn({ id, duration })
+  } else {
+    addEvent({ id, duration })
+  }
+}
+
+/**
  * @typedef {import('redux-bundler').Selectors<typeof selectors>} Selectors
  */
 
@@ -399,12 +416,7 @@ const createAnalyticsBundle = ({
         const payload = parseTask(action)
         if (payload) {
           const { id, duration, error } = payload
-          const addEventFn = addEventLimitedFns.get(id)
-          if (addEventFn != null) {
-            addEventFn({ id, duration })
-          } else {
-            addEvent({ id, duration })
-          }
+          addEventWrapped({ id, duration })
 
           // Record errors. Only from explicitly selected actions.
           if (error) {

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -168,7 +168,7 @@ function addEvent ({ id, duration }) {
  * You can limit how many times an event is recorded by adding them here.
  */
 const addEventLimitedFns = new Map([
-  ['IPFS_INIT_FAILED', onlyOnceAfter(5, addEvent)]
+  ['IPFS_INIT_FAILED', onlyOnceAfter(addEvent, 5)]
 ])
 
 /**

--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -366,7 +366,11 @@ const actions = {
       }
 
       const result = await getIpfs({
-        // @ts-ignore - TS can't seem to infer connectionTest option
+        /**
+         *
+         * @param {import('kubo-rpc-client').IPFSHTTPClient} ipfs
+         * @returns {Promise<boolean>}
+         */
         connectionTest: async (ipfs) => {
           // ipfs connection is working if can we fetch the bw stats.
           // See: https://github.com/ipfs-shipyard/ipfs-webui/issues/835#issuecomment-466966884

--- a/src/bundles/retry-init.js
+++ b/src/bundles/retry-init.js
@@ -6,13 +6,10 @@ import { ACTIONS } from './ipfs-provider.js'
  * @typedef {Object} AppIdle
  * @property {'APP_IDLE'} type
  *
- * @typedef {Object} EnableRetryInit
- * @property {'RETRY_INIT_ENABLE'} type
- *
  * @typedef {Object} DisableRetryInit
  * @property {'RETRY_INIT_DISABLE'} type
  *
- * @typedef {import('./ipfs-provider').Message | AppIdle | EnableRetryInit | DisableRetryInit} Message
+ * @typedef {import('./ipfs-provider').Message | AppIdle | DisableRetryInit} Message
  *
  * @typedef {Object} Model
  * @property {number} [startedAt]
@@ -39,7 +36,6 @@ const initialState = () => ({ tryCount: 0, needToRetry: true, startedAt: undefin
  * @returns {Model}
  */
 const disabledState = () => {
-  console.trace('disabledState')
   return ({ ...initialState(), needToRetry: false })
 }
 
@@ -49,14 +45,6 @@ const disabledState = () => {
 const retryInit = {
   name: 'retryInit',
 
-  // /**
-  //  *
-  //  * @param {import('redux-bundler').Store<Model, Message>} store
-  //  */
-  // init: (store) => {
-  //   store.dispatch({ type: 'RETRY_INIT_ENABLE' })
-  // },
-
   /**
    * @param {Model} state
    * @param {Message} action
@@ -64,16 +52,6 @@ const retryInit = {
    */
   reducer: (state = initialState(), action) => {
     switch (action.type) {
-      // case 'APP_IDLE': {
-      //   console.log('app_idle event emitted')
-      //   /**
-      //    * Do not retry if the app is idle
-      //    */
-      //   return disabledState()
-      // }
-      // case 'RETRY_INIT_ENABLE': {
-      //   return initialState()
-      // }
       case 'RETRY_INIT_DISABLE': {
         return disabledState()
       }

--- a/src/bundles/retry-init.js
+++ b/src/bundles/retry-init.js
@@ -2,38 +2,100 @@ import { createSelector } from 'redux-bundler'
 import { ACTIONS } from './ipfs-provider.js'
 
 /**
- * @typedef {import('./ipfs-provider').Message} Message
+ *
+ * @typedef {Object} AppIdle
+ * @property {'APP_IDLE'} type
+ *
+ * @typedef {Object} EnableRetryInit
+ * @property {'RETRY_INIT_ENABLE'} type
+ *
+ * @typedef {Object} DisableRetryInit
+ * @property {'RETRY_INIT_DISABLE'} type
+ *
+ * @typedef {import('./ipfs-provider').Message | AppIdle | EnableRetryInit | DisableRetryInit} Message
+ *
  * @typedef {Object} Model
  * @property {number} [startedAt]
  * @property {number} [failedAt]
+ * @property {number} [tryCount]
+ * @property {boolean} [needToRetry]
+ * @property {number} [intervalId]
+ * @property {boolean} currentlyTrying
  *
  * @typedef {Object} State
  * @property {Model} retryInit
+ *
  */
+
+const retryTime = 2500
+const maxRetries = 5
+
+/**
+ * @returns {Model}
+ */
+const initialState = () => ({ tryCount: 0, needToRetry: true, startedAt: undefined, failedAt: undefined, currentlyTrying: false })
+
+/**
+ * @returns {Model}
+ */
+const disabledState = () => {
+  console.trace('disabledState')
+  return ({ ...initialState(), needToRetry: false })
+}
 
 // We ask for the stats every few seconds, so that gives a good indication
 // that ipfs things are working (or not), without additional polling of the api.
+
 const retryInit = {
   name: 'retryInit',
+
+  // /**
+  //  *
+  //  * @param {import('redux-bundler').Store<Model, Message>} store
+  //  */
+  // init: (store) => {
+  //   store.dispatch({ type: 'RETRY_INIT_ENABLE' })
+  // },
 
   /**
    * @param {Model} state
    * @param {Message} action
    * @returns {Model}
    */
-  reducer: (state = {}, action) => {
+  reducer: (state = initialState(), action) => {
     switch (action.type) {
+      // case 'APP_IDLE': {
+      //   console.log('app_idle event emitted')
+      //   /**
+      //    * Do not retry if the app is idle
+      //    */
+      //   return disabledState()
+      // }
+      // case 'RETRY_INIT_ENABLE': {
+      //   return initialState()
+      // }
+      case 'RETRY_INIT_DISABLE': {
+        return disabledState()
+      }
       case ACTIONS.IPFS_INIT: {
         const { task } = action
         switch (task.status) {
           case 'Init': {
-            return { ...state, startedAt: Date.now() }
+            const startedAt = Date.now()
+            return {
+              ...state,
+              currentlyTrying: true,
+              startedAt, // new init attempt, set startedAt
+              tryCount: (state.tryCount || 0) + 1 // increase tryCount
+            }
           }
           case 'Exit': {
             if (task.result.ok) {
-              return state
+              // things are okay, reset the state
+              return disabledState()
             } else {
-              return { ...state, failedAt: Date.now() }
+              const failedAt = Date.now()
+              return { ...state, failedAt, currentlyTrying: false }
             }
           }
           default: {
@@ -48,27 +110,40 @@ const retryInit = {
   },
 
   /**
-   * @param {State} state
+   * @returns {(context: import('redux-bundler').Context<Model, Message, unknown>) => void}
    */
-  selectInitStartedAt: state => state.retryInit.startedAt,
+  doDisableRetryInit: () => (context) => {
+    // we should emit IPFS_INIT_FAILED at this point
+    context.dispatch({
+      type: 'RETRY_INIT_DISABLE'
+    })
+  },
 
   /**
    * @param {State} state
    */
-  selectInitFailedAt: state => state.retryInit.failedAt,
+  selectRetryInitState: state => state.retryInit,
 
+  /**
+   * This is continuously called by the app
+   * @see https://reduxbundler.com/api-reference/bundle#bundle.reactx
+   */
   reactConnectionInitRetry: createSelector(
-    'selectAppTime',
-    'selectInitStartedAt',
-    'selectInitFailedAt',
+    'selectAppTime', // this is the current time of the app.. we need this to compare against startedAt
+    'selectIpfsReady',
+    'selectRetryInitState',
     /**
-     * @param {number} appTime
-     * @param {number|void} startedAt
-     * @param {number|void} failedAt
+     * @param {number|void} appTime
+     * @param {boolean} ipfsReady
+     * @param {Model} state
      */
-    (appTime, startedAt, failedAt) => {
-      if (!failedAt || failedAt < startedAt) return false
-      if (appTime - failedAt < 3000) return false
+    (appTime, ipfsReady, { failedAt, tryCount, needToRetry, currentlyTrying }) => {
+      if (currentlyTrying) return false // if we are currently trying, don't try again
+      if (!appTime) return false // This should never happen; see https://reduxbundler.com/api-reference/included-bundles#apptimebundle
+      if (!needToRetry) return false // we should not be retrying, so don't.
+      if (tryCount != null && tryCount > maxRetries) return { actionCreator: 'doDisableRetryInit' }
+      if (ipfsReady) return { actionCreator: 'doDisableRetryInit' } // when IPFS is ready, we don't need to retry
+      if (!failedAt || appTime - failedAt < retryTime) return false
       return { actionCreator: 'doTryInitIpfs' }
     }
   )

--- a/src/lib/guards.js
+++ b/src/lib/guards.js
@@ -1,0 +1,23 @@
+/**
+ *
+ * @param {any} value
+ * @param {boolean} [throwOnFalse]
+ * @returns {value is Function}
+ */
+export function isFunction (value, throwOnFalse = true) {
+  if (typeof value === 'function') { return true }
+  if (throwOnFalse) { throw new TypeError('Expected a function') }
+  return false
+}
+
+/**
+ *
+ * @param {any} value
+ * @param {boolean} [throwOnFalse]
+ * @returns {value is number}
+ */
+export function isNumber (value, throwOnFalse = true) {
+  if (typeof value === 'number') { return true }
+  if (throwOnFalse) { throw new TypeError('Expected a number') }
+  return false
+}

--- a/src/lib/guards.test.js
+++ b/src/lib/guards.test.js
@@ -1,0 +1,31 @@
+import { isFunction, isNumber } from './guards.js'
+
+describe('lib/guards', function () {
+  describe('isFunction', function () {
+    it('should return true if the passed value is a function', function () {
+      expect(isFunction(() => {})).toBe(true)
+    })
+
+    it('should throw an error if the passed value is not a function', function () {
+      expect(() => isFunction('not a function')).toThrow(TypeError)
+    })
+
+    it('should return false if the passed value is not a function and throwOnFalse is false', function () {
+      expect(isFunction('not a function', false)).toBe(false)
+    })
+  })
+
+  describe('isNumber', function () {
+    it('should return true if the passed value is a function', function () {
+      expect(isNumber(1)).toBe(true)
+    })
+
+    it('should throw an error if the passed value is not a function', function () {
+      expect(() => isNumber('not a number')).toThrow(TypeError)
+    })
+
+    it('should return false if the passed value is not a function and throwOnFalse is false', function () {
+      expect(isNumber('not a number', false)).toBe(false)
+    })
+  })
+})

--- a/src/lib/hofs/functions.js
+++ b/src/lib/hofs/functions.js
@@ -1,0 +1,36 @@
+/**
+ * This method creates a function that invokes func once it’s called n or more times.
+ * @see https://youmightnotneed.com/lodash#after
+ * @type {<A, R>(times: number, fn: (...args: A[]) => R) => (...args: A[]) => void | R}
+ */
+export const after = (times, fn) => {
+  let counter = 0
+  return (...args) => {
+    counter++
+    if (counter >= times) {
+      return fn(...args)
+    }
+  }
+}
+/**
+ * @see https://youmightnotneed.com/lodash#once
+ * @type {<A, R>(fn: (...args: A[]) => R) => (...args: A[]) => R}
+ */
+export const once = (fn) => {
+  let called = false
+  let result
+  return (...args) => {
+    if (!called) {
+      result = fn(...args)
+      called = true
+    }
+    return result
+  }
+}
+/**
+ * Call a function only once on the nth time it was called
+ * @type {<A, R>(nth: number, fn: (...args: A[]) => R) => (...args: A[]) => void | R}
+ */
+export const onlyOnceAfter = (nth, fn) => {
+  return after(nth, once(fn))
+}

--- a/src/lib/hofs/functions.js
+++ b/src/lib/hofs/functions.js
@@ -47,11 +47,38 @@ export const once = (fn) => {
 }
 
 /**
+ * @see https://youmightnotneed.com/lodash#debounce
+ *
+ * @template A
+ * @template R
+ * @param {(...args: A[]) => R} fn - The function to debounce.
+ * @param {number} delay - The number of milliseconds to delay.
+ * @param {Object} options
+ * @param {boolean} [options.leading]
+ * @returns {(...args: A[]) => void}
+ */
+export const debounce = (fn, delay, { leading = false } = {}) => {
+  /**
+   * @type {NodeJS.Timeout}
+   */
+  let timerId
+
+  return (...args) => {
+    if (!timerId && leading) {
+      fn(...args)
+    }
+    clearTimeout(timerId)
+
+    timerId = setTimeout(() => fn(...args), delay)
+  }
+}
+
+/**
  * Call a function only once on the nth time it was called
  * @template A
  * @template R
- * @param {number} nth
- * @param {(...args: A[]) => R} fn
+ * @param {number} nth - The nth time the function should be called when it is actually invoked.
+ * @param {(...args: A[]) => R} fn - The function to call.
  * @returns {(...args: A[]) => void | R}
  */
 export const onlyOnceAfter = (nth, fn) => {

--- a/src/lib/hofs/functions.js
+++ b/src/lib/hofs/functions.js
@@ -1,3 +1,5 @@
+import { isFunction, isNumber } from '../guards.js'
+
 /**
  * This method creates a function that invokes func once it’s called n or more times.
  * @see https://youmightnotneed.com/lodash#after
@@ -7,7 +9,8 @@
  * @param {(...args: A[]) => R} fn
  * @returns {(...args: A[]) => void | R}
  */
-export const after = (times, fn) => {
+export const after = (fn, times) => {
+  isFunction(fn) && isNumber(times)
   let counter = 0
   /**
    * @type {(...args: A[]) => void | R}
@@ -28,6 +31,7 @@ export const after = (times, fn) => {
  * @returns {(...args: A[]) => R}
  */
 export const once = (fn) => {
+  isFunction(fn)
   let called = false
   /**
    * @type {R}
@@ -58,6 +62,7 @@ export const once = (fn) => {
  * @returns {(...args: A[]) => void}
  */
 export const debounce = (fn, delay, { leading = false } = {}) => {
+  isFunction(fn) && isNumber(delay)
   /**
    * @type {NodeJS.Timeout}
    */
@@ -81,6 +86,7 @@ export const debounce = (fn, delay, { leading = false } = {}) => {
  * @param {(...args: A[]) => R} fn - The function to call.
  * @returns {(...args: A[]) => void | R}
  */
-export const onlyOnceAfter = (nth, fn) => {
-  return after(nth, once(fn))
+export const onlyOnceAfter = (fn, nth) => {
+  isFunction(fn) && isNumber(nth)
+  return after(once(fn), nth)
 }

--- a/src/lib/hofs/functions.js
+++ b/src/lib/hofs/functions.js
@@ -1,10 +1,17 @@
 /**
  * This method creates a function that invokes func once it’s called n or more times.
  * @see https://youmightnotneed.com/lodash#after
- * @type {<A, R>(times: number, fn: (...args: A[]) => R) => (...args: A[]) => void | R}
+ * @template A
+ * @template R
+ * @param {number} times
+ * @param {(...args: A[]) => R} fn
+ * @returns {(...args: A[]) => void | R}
  */
 export const after = (times, fn) => {
   let counter = 0
+  /**
+   * @type {(...args: A[]) => void | R}
+   */
   return (...args) => {
     counter++
     if (counter >= times) {
@@ -12,13 +19,24 @@ export const after = (times, fn) => {
     }
   }
 }
+
 /**
  * @see https://youmightnotneed.com/lodash#once
- * @type {<A, R>(fn: (...args: A[]) => R) => (...args: A[]) => R}
+ * @template A
+ * @template R
+ * @param {(...args: A[]) => R} fn
+ * @returns {(...args: A[]) => R}
  */
 export const once = (fn) => {
   let called = false
+  /**
+   * @type {R}
+   */
   let result
+
+  /**
+   * @type {(...args: A[]) => R}
+   */
   return (...args) => {
     if (!called) {
       result = fn(...args)
@@ -27,9 +45,14 @@ export const once = (fn) => {
     return result
   }
 }
+
 /**
  * Call a function only once on the nth time it was called
- * @type {<A, R>(nth: number, fn: (...args: A[]) => R) => (...args: A[]) => void | R}
+ * @template A
+ * @template R
+ * @param {number} nth
+ * @param {(...args: A[]) => R} fn
+ * @returns {(...args: A[]) => void | R}
  */
 export const onlyOnceAfter = (nth, fn) => {
   return after(nth, once(fn))

--- a/src/lib/hofs/functions.test.js
+++ b/src/lib/hofs/functions.test.js
@@ -8,7 +8,7 @@ describe('hofFns', function () {
   describe('after', function () {
     it('should not call the function if the threshold has not been reached', function () {
       const fn = jest.fn()
-      const afterFn = after(10, fn)
+      const afterFn = after(fn, 10)
 
       afterFn()
       afterFn()
@@ -19,13 +19,21 @@ describe('hofFns', function () {
 
     it('should call the function if the threshold has been reached', function () {
       const fn = jest.fn()
-      const afterFn = after(3, fn)
+      const afterFn = after(fn, 3)
 
       afterFn()
       afterFn()
       afterFn()
 
       expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw an error if the passed fn is not a function', function () {
+      expect(() => after('not a function', 3)).toThrow(TypeError)
+    })
+
+    it('should throw an error if times is not a number', function () {
+      expect(() => after(jest.fn(), 'not a number')).toThrow(TypeError)
     })
   })
 
@@ -39,6 +47,10 @@ describe('hofFns', function () {
       onceFn()
 
       expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw an error if the passed fn is not a function', function () {
+      expect(() => once('not a function')).toThrow(TypeError)
     })
   })
 
@@ -57,12 +69,16 @@ describe('hofFns', function () {
 
       expect(fn).toHaveBeenCalledTimes(1)
     })
+
+    it('should throw an error if the passed fn is not a function', function () {
+      expect(() => debounce('not a function')).toThrow(TypeError)
+    })
   })
 
   describe('onlyOnceAfter', function () {
     it('should not call the function unless n is reached', function () {
       const fn = jest.fn()
-      const onlyOnceAfterFn = onlyOnceAfter(5, fn)
+      const onlyOnceAfterFn = onlyOnceAfter(fn, 5)
 
       onlyOnceAfterFn()
       onlyOnceAfterFn()
@@ -73,7 +89,7 @@ describe('hofFns', function () {
 
     it('should call the function only once after n+m calls', function () {
       const fn = jest.fn()
-      const onlyOnceAfterFn = onlyOnceAfter(5, fn)
+      const onlyOnceAfterFn = onlyOnceAfter(fn, 5)
 
       onlyOnceAfterFn()
       onlyOnceAfterFn()
@@ -85,6 +101,14 @@ describe('hofFns', function () {
       onlyOnceAfterFn()
 
       expect(fn).toHaveBeenCalledTimes(1)
+    })
+
+    it('should throw an error if the passed fn is not a function', function () {
+      expect(() => onlyOnceAfter('not a function', 2)).toThrow(TypeError)
+    })
+
+    it('should throw an error if nth is not a number', function () {
+      expect(() => onlyOnceAfter(jest.fn(), 'not a number')).toThrow(TypeError)
     })
   })
 })

--- a/src/lib/hofs/functions.test.js
+++ b/src/lib/hofs/functions.test.js
@@ -1,0 +1,90 @@
+import { jest } from '@jest/globals'
+
+import { after, debounce, once, onlyOnceAfter } from './functions.js'
+
+jest.useFakeTimers()
+
+describe('hofFns', function () {
+  describe('after', function () {
+    it('should not call the function if the threshold has not been reached', function () {
+      const fn = jest.fn()
+      const afterFn = after(10, fn)
+
+      afterFn()
+      afterFn()
+      afterFn()
+
+      expect(fn).toHaveBeenCalledTimes(0)
+    })
+
+    it('should call the function if the threshold has been reached', function () {
+      const fn = jest.fn()
+      const afterFn = after(3, fn)
+
+      afterFn()
+      afterFn()
+      afterFn()
+
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('once', function () {
+    it('should call the function only once', function () {
+      const fn = jest.fn()
+      const onceFn = once(fn)
+
+      onceFn()
+      onceFn()
+      onceFn()
+
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('debounce', function () {
+    it('should call the function only once within the given timeframe', function () {
+      const fn = jest.fn()
+      const debounceFn = debounce(fn, 100)
+
+      debounceFn()
+      debounceFn()
+      debounceFn()
+
+      expect(fn).toHaveBeenCalledTimes(0)
+
+      jest.advanceTimersByTime(100)
+
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('onlyOnceAfter', function () {
+    it('should not call the function unless n is reached', function () {
+      const fn = jest.fn()
+      const onlyOnceAfterFn = onlyOnceAfter(5, fn)
+
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+
+      expect(fn).toHaveBeenCalledTimes(0)
+    })
+
+    it('should call the function only once after n+m calls', function () {
+      const fn = jest.fn()
+      const onlyOnceAfterFn = onlyOnceAfter(5, fn)
+
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+      onlyOnceAfterFn()
+
+      expect(fn).toHaveBeenCalledTimes(1)
+    })
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,11 +53,29 @@
   },
   "exclude": [
     "./src/test",
-    "src/**/*.test.js"
+    "src/**/*.test.js",
   ],
   "include": [
     "**/*.ts",
     "@types",
-    "src/**/*.js",
+    // "src/**/*.js", // TODO: Include all js files when typecheck passes
+    "src/bundles/files/**/*.js",
+    "src/bundles/analytics.js",
+    "src/bundles/config-save.js",
+    "src/bundles/connected.js",
+    "src/bundles/enum.js",
+    "src/bundles/experiments.js",
+    "src/bundles/ipfs-desktop.js",
+    "src/bundles/ipfs-provider.js",
+    "src/bundles/retry-init.js",
+    "src/bundles/retry-init.js",
+    "src/bundles/local-storage.js",
+    "src/bundles/task.js",
+    "src/lib/count-dirs.js",
+    "src/lib/sort.js",
+    "src/lib/files.js",
+    "src/env.js",
+    "src/lib/hofs/**/*.js",
+    "src/lib/guards.js",
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -52,26 +52,12 @@
     "module": "esnext"
   },
   "exclude": [
-    "./src/test"
+    "./src/test",
+    "src/**/*.test.js"
   ],
   "include": [
     "**/*.ts",
     "@types",
-    "src/bundles/files/**/*.js",
-    "src/bundles/analytics.js",
-    "src/bundles/config-save.js",
-    "src/bundles/connected.js",
-    "src/bundles/enum.js",
-    "src/bundles/experiments.js",
-    "src/bundles/ipfs-desktop.js",
-    "src/bundles/ipfs-provider.js",
-    "src/bundles/retry-init.js",
-    "src/bundles/retry-init.js",
-    "src/bundles/local-storage.js",
-    "src/bundles/task.js",
-    "src/lib/count-dirs.js",
-    "src/lib/sort.js",
-    "src/lib/files.js",
-    "src/env.js"
+    "src/**/*.js",
   ]
 }


### PR DESCRIPTION
WIP.

fixes #1831

* Only send IPFS_INIT_FAILED event after 5 attempts
* Only send the IPFS_INIT_FAILED event once per app-load
* Stop the retry-init process after a certain number of attempts


Note: We can debounce these and send only 1 every 5 min or so, but we're in breach of our countly contract currently because IPFS_INIT_FAILED is currently sending 4.8MM of these events from IPFS Desktop and 2MM from IPFS Web UI.

We do not need this many events to know if things are failing. Knowing how many times IPFS_INIT_FAILED per app load will be a MUCH better metric for informing how successful the app is for our users.

This also means, when the app boots up, if the user changes the API endpoint, we won't send an additional IPFS_INIT_FAILED metric.  If we want to get a metric for this, we'll have to do some logic around `IPFS_API_ADDRESS_UPDATED`, `IPFS_API_ADDRESS_PENDING_FIRST_CONNECTION`, and then the result of either `IPFS_CONNECT_SUCCEED` or `IPFS_CONNECT_FAILED`


---

# demo


https://github.com/ipfs/ipfs-webui/assets/1173416/9b468d04-893e-4e05-ab7e-f0878ac38d73

