### PR TITLE
fix(ci): e2e coverage

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -2,10 +2,48 @@ on:
   workflow_call:
 
 jobs:
+  test-build:
+    name: 'test:build'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3.5.3
+
+      - name: Setup node
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 18.14.0
+
+      - name: Cache bigger downloads
+        uses: actions/cache@v3.3.1
+        id: cache
+        with:
+          path: ${{ github.workspace }}/.cache
+          key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+
+      - name: Cache test-build output
+        uses: actions/cache@v3.3.1
+        id: test-build-cache
+        with:
+          path: build
+          key: test-build-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            test-build-${{ runner.os }}-${{ github.sha }}
+
+      # This is required to ensure that our code is instrumented with coverage details
+      - name: Run test build
+        if: steps.test-build-cache.outputs.cache-hit != 'true'
+        run: npm run test:build
 
   test-e2e:
     name: 'test:e2e'
     runs-on: ubuntu-latest
+    needs: [test-build]
     strategy:
       fail-fast: false
       matrix:
@@ -35,8 +73,18 @@ jobs:
       - name: Install playwright browsers
         run: npx playwright install --with-deps
 
+      - name: Cache test-build output
+        uses: actions/cache@v3.3.1
+        id: test-build-cache
+        with:
+          path: build
+          key: test-build-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            test-build-${{ runner.os }}-${{ github.sha }}
+
       # This is required to ensure that our code is instrumented with coverage details
       - name: Run test build
+        if: steps.test-build-cache.outputs.cache-hit != 'true'
         run: npm run test:build
 
       - name: Cache nyc_output dir

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -39,6 +39,15 @@ jobs:
       - name: Run test build
         run: npm run test:build
 
+      - name: Cache nyc_output dir
+        uses: actions/cache@v3.3.1
+        id: nyc_output-cache
+        with:
+          path: ./.nyc_output
+          key: nyc_output-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nyc_output-${{ runner.os }}-${{ github.sha }}
+
       - name: Run repeated-E2E against Kubo
         if: github.ref != 'refs/heads/main' # only run duplicated e2e tests on PRs
         run: npm run test:e2e -- --repeat-each 10 --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} # run each test 10 times to ensure no flakiness
@@ -46,6 +55,41 @@ jobs:
       - name: Run non-repeated-E2E against Kubo
         if: github.ref == 'refs/heads/main' # run non-duplicated tests on non-PRs
         run: npm run test:e2e -- --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+
+  e2e-coverage: # since we run coverage in shards and some files may not contain coverage, we cache the .nyc_output directory
+    name: 'e2e-coverage'
+    runs-on: ubuntu-latest
+    needs: [test-e2e]
+    steps:
+      - uses: actions/checkout@v3.5.3
+
+      - name: Setup node
+        uses: actions/setup-node@v3.6.0
+        with:
+          node-version: 18.14.0
+
+      - name: Cache bigger downloads
+        uses: actions/cache@v3.3.1
+        id: cache
+        with:
+          path: ${{ github.workspace }}/.cache
+          key: ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
+            ${{ runner.os }}-
+
+
+      - name: Install dependencies
+        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
+
+      - name: Cache nyc_output dir
+        uses: actions/cache@v3.3.1
+        id: nyc_output-cache
+        with:
+          path: ./.nyc_output
+          key: nyc_output-${{ runner.os }}-${{ github.sha }}
+          restore-keys: |
+            nyc_output-${{ runner.os }}-${{ github.sha }}
 
       - name: Generate nyc coverage report
         id: coverage

--- a/config-overrides.js
+++ b/config-overrides.js
@@ -110,6 +110,7 @@ function webpackOverride (config) {
   const REACT_APP_ENV = process.env.REACT_APP_ENV ?? process.env.NODE_ENV ?? 'development'
   if (REACT_APP_ENV === 'test') {
     config.module.rules = modifyBabelLoaderRuleForTest(config.module.rules)
+    config.devtool = 'inline-source-map'
   } else if (REACT_APP_ENV === 'development') {
     config.optimization = {
       ...config.optimization,


### PR DESCRIPTION
e2e tests were failing due to sharding and lack of coverage found in some shards: https://github.com/ipfs/ipfs-webui/actions/runs/5650403570

This PR fixes that. It also batches some actions that *should* be batched.

* caches the test:build so all shard runs don't have to build before running
* caches the .nyc_output folder so all shard runs don't have to emit their own coverage

which should result in the e2e tests being faster overall.


**Successful run on SgtPooki/ipfs-webui**: https://github.com/SgtPooki/ipfs-webui/actions/runs/5651849593