### PR TITLE
fix: replace estuary with web3 for pinning

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,19 +23,21 @@ jobs:
             ${{ runner.os }}-${{ hashFiles('package.json', 'package-lock.json') }}
             ${{ runner.os }}-
 
-      - name: Install dependencies
-        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
-
       # Separate cache for build dir, we reuse it in release publish workflow
       - name: Cache build output
-        if: startsWith(github.ref, 'refs/tags/v')
         uses: actions/cache@v3.3.1
         id: build-cache
         with:
           path: build
-          key: ${{ runner.os }}-${{ github.sha }}
+          # Build hash should be based on runner.os, src files, and dependencies used.
+          key: ${{ runner.os }}-build-${{ hashFiles('package.json', 'package-lock.json', 'public', 'src/**', '*.js', '*.ts') }}
           restore-keys: |
-            ${{ runner.os }}-${{ github.sha }}
+            ${{ runner.os }}-build-${{ hashFiles('package.json', 'package-lock.json', 'public', 'src/**', '*.js', '*.ts') }}
+
+      - name: Install dependencies
+        # We only need to install deps if build isn't cached.
+        if: steps.build-cache.outputs.cache-hit != 'true'
+        run: npm ci --prefer-offline --no-audit --progress=false --cache ${{ github.workspace }}/.cache/npm
 
       - name: Confirm build works
         if: steps.build-cache.outputs.cache-hit != 'true'
@@ -47,6 +49,6 @@ jobs:
       - name: Attach produced build to Github Action
         uses: actions/upload-artifact@v3
         with:
-          name: ipfs-webui_${{ github.sha }}-build
+          name: ipfs-webui_${{ github.sha }}-${{ runner.os }}-build
           path: build
           if-no-files-found: error

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@v3
         with:
-          name: ipfs-webui_${{ github.sha }}-build
+          name: ipfs-webui_${{ github.sha }}-${{ runner.os }}-build
           path: build
 
       - name: Cache bigger downloads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,19 +85,38 @@ jobs:
           path: ipfs-webui_${{ github.sha }}.car
           if-no-files-found: error
 
-      - name: Pin to estuary.tech
-        id: pin-estuary
+      # Instructions for this are at https://github.com/ipfs/ipfs-webui/issues/2161#issuecomment-1836835068
+      - name: Pin to web3.storage with w3cli
+        id: pin-w3up
+        # only pin for main commits
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
-          curl -X POST https://api.estuary.tech/pinning/pins -d '{ "name": "'$PIN_NAME'", "cid": "'$PIN_CID'" }' -H "Content-Type: application/json" -H "Authorization: Bearer $ESTUARY_API_TOKEN"
-          curl -X GET https://api.estuary.tech/pinning/pins -H "Content-Type: application/json" -H "Authorization: Bearer $ESTUARY_API_TOKEN"
+          # ensure whoami
+          npx -y --package=@web3-storage/w3cli@latest -- w3 whoami
+
+          # convert base64 env var to file
+          echo $W3CLI_SPACE_DELEGATION_PROOF_BASE64_STRING | base64 -d > ipfs-webui-ci-space.ucan.proof
+
+          # Add space
+          export W3CLI_SPACE_DID=$(npx -y --package=@web3-storage/w3cli@latest -- w3 space add ipfs-webui-ci-space.ucan.proof)
+
+          # use space
+          npx -y --package=@web3-storage/w3cli@latest -- w3 space use $W3CLI_SPACE_DID
+
+          # upload car
+          npx -y --package=@web3-storage/w3cli@latest -- w3 up --no-wrap -c ipfs-webui_${{ github.sha }}.car
         env:
-          ESTUARY_API_TOKEN: ${{ secrets.ESTUARY_API_TOKEN }}
-          PIN_CID: ${{ steps.ipfs.outputs.cid }}
-          PIN_NAME: "ipfs-webui@${{ github.sha }}"
+          W3_STORE_NAME: ipfs-webui-ci
+          W3_AGENT_DID: ${{ secrets.W3_AGENT_DID }}
+          # set w3cli principal from https://github.com/web3-storage/w3cli#w3_principal
+          W3_PRINCIPAL: ${{ secrets.W3_AGENT_PRINCIPAL }}
+          W3CLI_SPACE_DELEGATION_PROOF_BASE64_STRING: ${{ secrets.W3CLI_SPACE_DELEGATION_PROOF_BASE64_STRING }}
 
       - name: Pin to ipfs-websites.collab.ipfscluster.io
         id: pin-cluster
+        # only pin for main commits
+        if: github.ref == 'refs/heads/main'
         continue-on-error: true
         run: |
           ipfs-cluster-ctl --enc=json \
@@ -125,7 +144,8 @@ jobs:
           PIN_NAME: "ipfs-webui@${{ github.sha }}"
 
       - name: Fail job due to pinning failure
-        if: steps.pin-estuary.outcome == 'failure' && steps.pin-cluster.outcome == 'failure'
+        # only fail if pinning failed for main commits
+        if: github.ref == 'refs/heads/main' && steps.pin-w3up.outcome == 'failure' && steps.pin-cluster.outcome == 'failure'
         uses: actions/github-script@v6
         with:
           script: |


### PR DESCRIPTION
- chore(ci): better build caching
- fix: use w3cli instead of estuary for pinning

Lots of work was done behind the scenes for this. See https://github.com/ipfs/ipfs-webui/issues/2161 for more details.

Of particular note are:
- The instructions listed at https://github.com/ipfs/ipfs-webui/issues/2161#issuecomment-1836835068
- The successful CI action at https://github.com/SgtPooki/ipfs-webui/actions/runs/7066688311/job/19239006867

