### PR TITLE
chore: disable countly analytics and hide unused UI

### DIFF
--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -65,11 +65,17 @@ import { onlyOnceAfter } from '../lib/hofs/functions.js'
  * @property {number} lastDisabledAt
  * @property {string[]} consent
  * @property {boolean?} showAnalyticsBanner
+ * @property {boolean?} showAnalyticsComponents
  * @property {boolean?} optedOut
  *
  * @typedef {Object} State
  * @property {Model} analytics
  */
+
+// 2024-Q2:
+// All analytics are disabled since we no longer use Countly instance.
+// See https://github.com/ipfs/ipfs-webui/issues/2198
+const DISABLE_ALL_ANALYTICS = true
 
 // Unknown actions (can't seem to see anything
 // dispatching those).
@@ -213,6 +219,11 @@ const selectors = {
    * @param {State} state
    */
   selectAnalyticsOptedOut: (state) => state.analytics.optedOut,
+  /**
+   * Show or hide all UI compontent related to analytics.
+   * @param {State} state
+   */
+  selectShowAnalyticsComponents: (state) => state.analytics.showAnalyticsComponents,
   /**
    * Show or hide the analytics banner.
    * @param {State} state
@@ -442,8 +453,9 @@ const createAnalyticsBundle = ({
       state = state || {
         lastEnabledAt: 0,
         lastDisabledAt: 0,
+        showAnalyticsComponents: DISABLE_ALL_ANALYTICS, // hide related UI  for now, see https://github.com/ipfs/ipfs-webui/issues/2198
         showAnalyticsBanner: false,
-        optedOut: false,
+        optedOut: !DISABLE_ALL_ANALYTICS, // disable analytics by default for now, see https://github.com/ipfs/ipfs-webui/issues/2198
         consent: []
       }
 

--- a/src/bundles/analytics.js
+++ b/src/bundles/analytics.js
@@ -453,9 +453,9 @@ const createAnalyticsBundle = ({
       state = state || {
         lastEnabledAt: 0,
         lastDisabledAt: 0,
-        showAnalyticsComponents: DISABLE_ALL_ANALYTICS, // hide related UI  for now, see https://github.com/ipfs/ipfs-webui/issues/2198
+        showAnalyticsComponents: !DISABLE_ALL_ANALYTICS, // hide related UI  for now, see https://github.com/ipfs/ipfs-webui/issues/2198
         showAnalyticsBanner: false,
-        optedOut: !DISABLE_ALL_ANALYTICS, // disable analytics by default for now, see https://github.com/ipfs/ipfs-webui/issues/2198
+        optedOut: DISABLE_ALL_ANALYTICS, // disable analytics by default for now, see https://github.com/ipfs/ipfs-webui/issues/2198
         consent: []
       }
 

--- a/src/bundles/analytics.test.js
+++ b/src/bundles/analytics.test.js
@@ -35,6 +35,17 @@ function createStore (analyticsOpts = {}, mockAnalyticsCachedState) {
 }
 
 describe('new/returning user default behavior', () => {
+  // 2024-Q2: disabling and hiding all metrics for now
+  // https://github.com/ipfs/ipfs-webui/pull/2216
+  it('should disable analytics by default and hide all UI compontents', () => {
+    const store = createStore()
+    expect(store.selectAnalyticsEnabled()).toBe(false)
+    expect(store.selectShowAnalyticsComponents()).toBe(false)
+    expect(store.selectAnalyticsConsent()).toEqual([])
+    expect(global.Countly.opt_in).not.toHaveBeenCalled()
+    expect(global.Countly.opt_out).not.toHaveBeenCalled()
+  })
+  /*
   it('should enable analytics by default for new user who has not opted in or out', () => {
     const store = createStore()
     expect(global.Countly.opt_in).toHaveBeenCalled()
@@ -42,6 +53,7 @@ describe('new/returning user default behavior', () => {
     // events will be sent as consents have been given by default
     expect(store.selectAnalyticsConsent()).toEqual(['sessions', 'events', 'views', 'location'])
   })
+  */
   it('should enable existing analytics by default for returning user who was opted_in', () => {
     const mockDefaultState = {
       lastEnabledAt: (new Date('2022-01-02')).getTime(),

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -33,6 +33,7 @@ export const SettingsPage = ({
   isLoading, isSaving, arePinningServicesSupported,
   hasSaveFailed, hasSaveSucceded, hasErrors, hasLocalChanges, hasExternalChanges,
   config, onChange, onReset, onSave, editorKey, analyticsEnabled, doToggleAnalytics,
+  showAnalyticsComponents,
   toursEnabled, handleJoyrideCallback, isCliTutorModeEnabled, doToggleCliTutorMode, command
 }) => (
   <div data-id='SettingsPage' className='mw9 center'>
@@ -92,15 +93,17 @@ export const SettingsPage = ({
     </Box>
 
     <Box className='mb3 pa4-l pa2'>
-      <div className='mb4 joyride-settings-language'>
+      <div className='joyride-settings-language'>
         <Title>{t('language')}</Title>
         <LanguageSelector t={t} />
       </div>
 
-      <div className='joyride-settings-analytics'>
-        <Title>{t('analytics')}</Title>
-        <AnalyticsToggle t={t} doToggleAnalytics={doToggleAnalytics} analyticsEnabled={analyticsEnabled} />
-      </div>
+    { showAnalyticsComponents
+      ? <div className='mt4 joyride-settings-analytics'>
+          <Title>{t('analytics')}</Title>
+          <AnalyticsToggle t={t} doToggleAnalytics={doToggleAnalytics} analyticsEnabled={analyticsEnabled} />
+        </div>
+      : null }
     </Box>
 
     <Experiments t={t} />
@@ -376,6 +379,7 @@ export default connect(
   'selectConfigSaveLastError',
   'selectIsIpfsDesktop',
   'selectToursEnabled',
+  'selectShowAnalyticsComponents',
   'selectAnalyticsEnabled',
   'selectArePinningServicesSupported',
   'doToggleAnalytics',

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -19,6 +19,7 @@ import withTour from '../components/tour/withTour.js'
 const StatusPage = ({
   t,
   ipfsConnected,
+  showAnalyticsComponents,
   showAnalyticsBanner,
   doEnableAnalytics,
   doDisableAnalytics,
@@ -53,7 +54,7 @@ const StatusPage = ({
           </div>
         </div>
       </Box>
-      { ipfsConnected && showAnalyticsBanner &&
+      { ipfsConnected && showAnalyticsComponents && showAnalyticsBanner &&
         <AnalyticsBanner
           className='mt3'
           label={t('AnalyticsBanner.label')}
@@ -92,6 +93,7 @@ export default connect(
   'selectIpfsConnected',
   'selectNodeBandwidthEnabled',
   'selectShowAnalyticsBanner',
+  'selectShowAnalyticsComponents',
   'selectToursEnabled',
   'doEnableAnalytics',
   'doDisableAnalytics',


### PR DESCRIPTION
This PR applies minimal changes to Close #2198 but without waiting for https://github.com/ipfs-shipyard/ignite-metrics/issues/133

- hide analytics UI components
- stop sending broken opt-out metrics to instance which no longer works

It does not remove any code, and allows restoring analytics once we have time to do https://github.com/ipfs-shipyard/ignite-metrics/issues/133.
