### PR TITLE
chore: switch to webui.ipfs.tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg)](https://protocol.ai/) [![](https://img.shields.io/github/release/ipfs/ipfs-webui.svg)](https://github.com/ipfs/ipfs-webui/releases/latest) [![i18n status](https://img.shields.io/badge/i18n-translated-blue.svg)](https://www.transifex.com/ipfs/ipfs-webui/) [![](https://img.shields.io/badge/matrix%20chat-%23lobby:ipfs.io-blue.svg?style=flat-square)](https://matrix.to/#/#lobby:ipfs.io)
 
-The [latest release version](https://github.com/ipfs/ipfs-webui/releases/latest) is always at https://webui.ipfs.io, and the preview of `main` branch is at https://dev.webui.ipfs.io.
+The [latest release version](https://github.com/ipfs/ipfs-webui/releases/latest) is always at https://webui.ipfs.tech, and the preview of `main` branch is at https://dev.webui.ipfs.tech.
 
 The IPFS WebUI is a **work-in-progress**. Help us make it better! We use the issues on this repo to track the work.
 
@@ -66,7 +66,7 @@ In separate shells run the following:
 
 You must configure your Kubo RPC endpoint at http://127.0.0.1:5001 to allow [cross-origin (CORS)](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) requests from your dev server at http://localhost:3000
 
-Similarly if you want to try out pre-release versions at https://dev.webui.ipfs.io you need to add that as an allowed domain too.
+Similarly if you want to try out pre-release versions at https://dev.webui.ipfs.tech you need to add that as an allowed domain too.
 
 #### Easy mode
 
@@ -79,7 +79,7 @@ Run the **[cors-config.sh](./cors-config.sh)** script with:
 #### The manual way
 
 ```sh
-> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000", "https://webui.ipfs.io", "http://127.0.0.1:5001"]'
+> ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin '["http://localhost:3000", "https://webui.ipfs.tech", "http://127.0.0.1:5001"]'
 > ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["POST"]'
 ```
 

--- a/cors-config.sh
+++ b/cors-config.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ALLOW_ORIGINS='"http://localhost:3000", "https://webui.ipfs.io", "https://dev.webui.ipfs.io"'
+ALLOW_ORIGINS='"http://localhost:3000", "https://webui.ipfs.tech", "https://dev.webui.ipfs.tech"'
 
 # stop executing if anything fails
 set -e

--- a/src/components/is-not-connected/IsNotConnected.js
+++ b/src/components/is-not-connected/IsNotConnected.js
@@ -15,7 +15,7 @@ const TABS = {
 
 const IsNotConnected = ({ t, apiUrl, connected, sameOrigin, ipfsApiAddress, doUpdateIpfsApiAddress }) => {
   const [activeTab, setActiveTab] = useState(TABS.UNIX)
-  const defaultDomains = ['http://localhost:3000', 'http://127.0.0.1:5001', 'https://webui.ipfs.io']
+  const defaultDomains = ['http://localhost:3000', 'http://127.0.0.1:5001', 'https://webui.ipfs.tech']
   const origin = window.location.origin
   const addOrigin = defaultDomains.indexOf(origin) === -1
   return (

--- a/src/env.test.js
+++ b/src/env.test.js
@@ -30,8 +30,8 @@ describe('env.js', function () {
     /**
      * webui.ipfs deployed endpoints
      */
-    testOriginAndEnv('https://webui.ipfs.io', () => {}, 'webui.ipfs', 0)
-    testOriginAndEnv('https://webui-ipfs-io.ipns.dweb.link/', () => {}, 'webui.ipfs', 0)
+    testOriginAndEnv('https://webui.ipfs.tech', () => {}, 'webui.ipfs', 0)
+    testOriginAndEnv('https://webui.ipfs.tech.ipns.dweb.link/', () => {}, 'webui.ipfs', 0)
     testOriginAndEnv('https://webui.ipfs.tech', () => {}, 'webui.ipfs', 0)
     testOriginAndEnv('https://some-random-url', () => { throw new Error('no match on origin') }, 'webui.ipfs', 1)
     testOriginAndEnv('https://some-random-url', () => ({ redirected: false, url: 'https://some-random-url/webui' }), 'webui.ipfs', 1)
@@ -39,9 +39,9 @@ describe('env.js', function () {
     /**
      * local webui endpoints
      */
-    testOriginAndEnv('http://webui.ipfs.io.ipns.localhost:8080/', () => {}, 'local', 0)
-    testOriginAndEnv('http://webui-ipfs.io.ipns.localhost:8080/', () => {}, 'local', 0)
-    testOriginAndEnv('http://webui.ipfs.io.ipns.localhost:48080/', () => {}, 'local', 0) // brave
+    testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:8080/', () => {}, 'local', 0)
+    testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:8080/', () => {}, 'local', 0)
+    testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:48080/', () => {}, 'local', 0) // brave
     testOriginAndEnv('http://localhost:3000/', () => { throw new Error('no match on origin') }, 'local', 1)
     testOriginAndEnv('http://127.0.0.1:3000/', () => { throw new Error('no match on origin') }, 'local', 1)
     testOriginAndEnv('https://some-random-url.localhost:3333', () => ({ redirected: false, url: 'https://some-random-url.localhost:3333/webui' }), 'local', 1)

--- a/src/env.test.js
+++ b/src/env.test.js
@@ -31,7 +31,7 @@ describe('env.js', function () {
      * webui.ipfs deployed endpoints
      */
     testOriginAndEnv('https://webui.ipfs.tech', () => {}, 'webui.ipfs', 0)
-    testOriginAndEnv('https://webui.ipfs.tech.ipns.dweb.link/', () => {}, 'webui.ipfs', 0)
+    testOriginAndEnv('https://webui-ipfs-tech.ipns.dweb.link/', () => {}, 'webui.ipfs', 0)
     testOriginAndEnv('https://webui.ipfs.tech', () => {}, 'webui.ipfs', 0)
     testOriginAndEnv('https://some-random-url', () => { throw new Error('no match on origin') }, 'webui.ipfs', 1)
     testOriginAndEnv('https://some-random-url', () => ({ redirected: false, url: 'https://some-random-url/webui' }), 'webui.ipfs', 1)
@@ -40,8 +40,9 @@ describe('env.js', function () {
      * local webui endpoints
      */
     testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:8080/', () => {}, 'local', 0)
-    testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:8080/', () => {}, 'local', 0)
+    testOriginAndEnv('http://webui-ipfs-tech.ipns.localhost:8080/', () => {}, 'local', 0)
     testOriginAndEnv('http://webui.ipfs.tech.ipns.localhost:48080/', () => {}, 'local', 0) // brave
+    testOriginAndEnv('http://webui-ipfs-tech.ipns.localhost:48080/', () => {}, 'local', 0) // brave
     testOriginAndEnv('http://localhost:3000/', () => { throw new Error('no match on origin') }, 'local', 1)
     testOriginAndEnv('http://127.0.0.1:3000/', () => { throw new Error('no match on origin') }, 'local', 1)
     testOriginAndEnv('https://some-random-url.localhost:3333', () => ({ redirected: false, url: 'https://some-random-url.localhost:3333/webui' }), 'local', 1)


### PR DESCRIPTION
This PR removes use of `.io` domains and finishes migration to `.tech`.
Wider context in: https://github.com/protocol/bifrost-infra/issues/2018

## TODO

Below things need to happen before merging:

- [ ] TLS setup from https://github.com/ipshipyard/waterworks-infra/issues/102 has to be set up first
- [ ] PR ipfs-companion replacing webui.ipfs.io with webui.ipfs.tech ([in all lines here](https://github.com/search?q=repo%3Aipfs%2Fipfs-companion+webui.ipfs.io+path%3A%2F%5Eadd-on%5C%2Fsrc%2F+&type=code))