### PR TITLE
fix: loading empty content

### DIFF
--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -113,7 +113,7 @@ const Preview = (props) => {
         return cantPreview
       }
 
-      if (!content) {
+      if (content===null) {
         return <ComponentLoader />
       }
 

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -113,7 +113,7 @@ const Preview = (props) => {
         return cantPreview
       }
 
-      if (content===null) {
+      if (content === null) {
         return <ComponentLoader />
       }
 


### PR DESCRIPTION
content may be an empty string but`!"" === true` so it will use` ComponentLoader`, but we should load it as it has content(empty content)