### PR TITLE
feat(remotepins): add Functionland Fula

### DIFF
--- a/src/components/pinning-manager/fixtures/pinningServices.js
+++ b/src/components/pinning-manager/fixtures/pinningServices.js
@@ -17,6 +17,12 @@ const services = [
     totalSize: 512000,
     bandwidthUsed: undefined,
     addedAt: new Date(1592491648691)
+  }, {
+    name: 'Functionland',
+    icon: 'https://fx.land/android-chrome-512x512.png',
+    totalSize: undefined,
+    bandwidthUsed: undefined,
+    addedAt: new Date(1687896930567)
   }
 ]
 

--- a/src/components/pinning-manager/fixtures/pinningServices.js
+++ b/src/components/pinning-manager/fixtures/pinningServices.js
@@ -12,17 +12,17 @@ const services = [
     bandwidthUsed: '2 GB/mo',
     addedAt: new Date(1592491648591)
   }, {
-    name: 'Eternum',
-    icon: 'https://www.eternum.io/static/images/icons/favicon-32x32.a2341c8ec160.png',
-    totalSize: 512000,
-    bandwidthUsed: undefined,
-    addedAt: new Date(1592491648691)
-  }, {
     name: 'Functionland',
     icon: 'https://fx.land/android-chrome-512x512.png',
     totalSize: undefined,
     bandwidthUsed: undefined,
     addedAt: new Date(1687896930567)
+  }, {
+    name: 'Eternum',
+    icon: 'https://www.eternum.io/static/images/icons/favicon-32x32.a2341c8ec160.png',
+    totalSize: 512000,
+    bandwidthUsed: undefined,
+    addedAt: new Date(1592491648691)
   }
 ]
 

--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -27,16 +27,16 @@ const pinningServiceTemplates = [
     visitServiceUrl: 'https://docs.pinata.cloud/api-reference/pinning-service-api'
   },
   {
-    name: 'Functionland',
-    icon: 'https://bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm.ipfs.dweb.link/',
-    apiEndpoint: 'https://api.cloud.fx.land',
-    visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
-  },
-  {
     name: 'Filebase',
     icon: 'https://dweb.link/ipfs/QmWBaeu6y1zEcKbsEqCuhuDHPL3W8pZouCPdafMCRCSUWk?filename=filebase.png',
     apiEndpoint: 'https://api.filebase.io/v1/ipfs',
     visitServiceUrl: 'https://docs.filebase.com/api-documentation/ipfs-pinning-service-api'
+  },
+  {
+    name: 'Functionland',
+    icon: 'https://bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm.ipfs.dweb.link/',
+    apiEndpoint: 'https://api.cloud.fx.land',
+    visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
   },
   {
     name: 'Web3.Storage',

--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -34,7 +34,7 @@ const pinningServiceTemplates = [
   },
   {
     name: 'Functionland',
-    icon: 'https://bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm.ipfs.dweb.link/',
+    icon: 'https://dweb.link/ipfs/bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm?filename=functionland.png',
     apiEndpoint: 'https://api.cloud.fx.land',
     visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
   },

--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -27,6 +27,12 @@ const pinningServiceTemplates = [
     visitServiceUrl: 'https://docs.pinata.cloud/api-reference/pinning-service-api'
   },
   {
+    name: 'Functionland',
+    icon: 'https://bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm.ipfs.dweb.link/',
+    apiEndpoint: 'https://api.cloud.fx.land',
+    visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
+  },
+  {
     name: 'Filebase',
     icon: 'https://dweb.link/ipfs/QmWBaeu6y1zEcKbsEqCuhuDHPL3W8pZouCPdafMCRCSUWk?filename=filebase.png',
     apiEndpoint: 'https://api.filebase.io/v1/ipfs',

--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -34,7 +34,7 @@ const pinningServiceTemplates = [
   },
   {
     name: 'Functionland',
-    icon: 'https://dweb.link/ipfs/bafybeidgnnvgm6i3pfzhjakgzcdwdbvwtmkkx7vzeiyvtk2b4oxis53vhm?filename=functionland.png',
+    icon: 'https://dweb.link/ipfs/QmWYEmdYq9Ry2xtb69oZSPXb8Aos24kWdVecsT3txVe38E?filename=functionland.svg',
     apiEndpoint: 'https://api.cloud.fx.land',
     visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
   },


### PR DESCRIPTION
Functionland Fula is an ipfs compatible DePIN network of 900 (as of 28/06/2024) individually owned and globally distributed nodes. The pinning service report is available at: [https://github.com/functionland/pinning-service/blob/main/api.cloud.fx.land.md](https://github.com/functionland/pinning-service/blob/main/api.cloud.fx.land.md)
Information on Functionland is avaialbe at https://fx.land and also https://www.crunchbase.com/organization/functionland/signals_and_news/timeline