### PR TITLE
fix(ui): replace IPFS API with Kubo RPC

### DIFF
--- a/cors-config.sh
+++ b/cors-config.sh
@@ -8,5 +8,5 @@ set -e
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Origin "[$ALLOW_ORIGINS]"
 ipfs config --json API.HTTPHeaders.Access-Control-Allow-Methods '["PUT", "POST"]'
 
-echo "IPFS API CORS headers configured for $ALLOW_ORIGINS"
+echo "Kubo RPC CORS headers configured for $ALLOW_ORIGINS"
 echo "Please restart your IPFS daemon"

--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -34,7 +34,7 @@
     "done": "Done"
   },
   "cliModal": {
-    "description": "Paste the following into your terminal to do this task in IPFS via the command line. Remember that you'll need to replace placeholders with your specific parameters."
+    "description": "Paste the following into your terminal to do this task in Kubo via the command line. Remember that you'll need to replace placeholders with your specific parameters."
   },
   "nav": {
     "bugsLink": "Report a bug",
@@ -43,7 +43,7 @@
   "status": {
     "connectedToIpfs": "Connected to IPFS",
     "connectingToIpfs": "Connecting to IPFS…",
-    "couldNotConnect": "Could not connect to the IPFS API"
+    "couldNotConnect": "Could not connect to the Kubo RPC"
   },
   "apiAddressForm": {
     "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
@@ -60,7 +60,7 @@
     "advanced": "Advanced",
     "agent": "Agent",
     "api": "Kubo RPC",
-    "apiAddress": "RPC API address",
+    "apiAddress": "Kubo RPC API address",
     "blocks": "Blocks",
     "connection": "Connection",
     "downSpeed": "Incoming",

--- a/public/locales/en/notify.json
+++ b/public/locales/en/notify.json
@@ -1,9 +1,9 @@
 {
   "ipfsApiRequestFailed": "Could not connect. Please check if your daemon is running.",
   "windowIpfsRequestFailed": "IPFS request failed. Please check your IPFS Companion settings.",
-  "ipfsInvalidApiAddress": "The provided IPFS API address is invalid.",
-  "ipfsConnectSuccess": "Successfully connected to the IPFS API address",
-  "ipfsConnectFail": "Unable to connect to the provided IPFS API address",
+  "ipfsInvalidApiAddress": "The provided Kubo RPC address is invalid.",
+  "ipfsConnectSuccess": "Successfully connected to the Kubo RPC address",
+  "ipfsConnectFail": "Unable to connect to the provided Kubo RPC address",
   "ipfsPinFailReason": "Unable to set pinning at {serviceName}: {errorMsg}",
   "ipfsPinSucceedReason": "Successfully pinned at {serviceName}",
   "ipfsUnpinSucceedReason": "Successfully unpinned from {serviceName}",

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -24,7 +24,7 @@
     },
     "step2": {
       "title": "Connection status",
-      "paragraph1": "Click this icon from anywhere in the app to return to the Status page. If you lose your connection to the IPFS API, the icon will turn red.",
+      "paragraph1": "Click this icon from anywhere in the app to return to the Status page. If you lose your connection to the Kubo RPC, the icon will turn red.",
       "paragraph2": "If you need to configure a custom API address for your node, just click the \"Edit\" link next to where the API address is listed on this page."
     },
     "step3": {

--- a/public/locales/en/welcome.json
+++ b/public/locales/en/welcome.json
@@ -6,9 +6,9 @@
   },
   "notConnected": {
     "paragraph1": "<0>Check out the installation guide in the <1>IPFS Docs</1>, or try these common fixes:</0>",
-    "paragraph2": "<0>Is your IPFS daemon running? Try starting or restarting it from your terminal:</0>",
-    "paragraph3": "<0>Is your IPFS API configured to allow <1>cross-origin (CORS) requests</1>? If not, run these commands and then start your daemon from the terminal:</0>",
-    "paragraph4": "<0>Is your IPFS API on a port other than 5001? If your node is configured with a <1>custom API address</1>, enter it here.</0>"
+    "paragraph2": "<0>Is your IPFS daemon running? Try starting or restarting Kubo from your terminal:</0>",
+    "paragraph3": "<0>Is your Kubo RPC API configured to allow <1>cross-origin (CORS) requests</1>? If not, run these commands and then start your daemon from the terminal:</0>",
+    "paragraph4": "<0>Is your Kubo RPC API on a port other than 5001? If your node is configured with a <1>custom API address</1>, enter it here.</0>"
   },
   "aboutIpfs": {
     "header": "What is IPFS?",
@@ -31,7 +31,7 @@
     "step1": {
       "title": "Welcome page",
       "paragraph1": "This page lets you know if you're connected to IPFS, and offers ideas for things you can do in this app.",
-      "paragraph2": "If you aren't connected to the IPFS API, this page also appears in place of some other pages, with hints for how to get connected.",
+      "paragraph2": "If you aren't connected to the Kubo RPC API, this page also appears in place of some other pages, with hints for how to get connected.",
       "paragraph3": "You can visit this page from anywhere in the app by clicking the IPFS cube logo in the navigation bar."
     }
   }

--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -393,7 +393,7 @@ const actions = {
       })
 
       if (!result) {
-        throw Error(`Could not connect to the IPFS API (${apiAddress})`)
+        throw Error(`Could not connect to the Kubo RPC (${apiAddress})`)
       } else {
         return result
       }
@@ -421,7 +421,7 @@ const actions = {
       await writeSetting('ipfsApi', apiAddress)
       context.dispatch({ type: ACTIONS.IPFS_API_ADDRESS_UPDATED, payload: apiAddress })
 
-      // Sends action to indicate we're going to try to update the IPFS API address.
+      // Sends action to indicate we're going to try to update the Kubo RPC address.
       // There is logic to retry doTryInitIpfs in bundles/retry-init.js, so
       // we're triggering the PENDING_FIRST_CONNECTION action here to avoid blocking
       // the UI while we automatically retry.

--- a/src/components/is-not-connected/IsNotConnected.js
+++ b/src/components/is-not-connected/IsNotConnected.js
@@ -29,17 +29,17 @@ const IsNotConnected = ({ t, apiUrl, connected, sameOrigin, ipfsApiAddress, doUp
       </Trans>
       <ol className='pl3 pt2'>
         <Trans i18nKey='notConnected.paragraph2' t={t}>
-          <li className='mb3'>Is your IPFS daemon running? Try starting or restarting it from your terminal:</li>
+          <li className='mb3'>Is your IPFS daemon running? Try starting or restarting Kubo from your terminal:</li>
         </Trans>
         <Shell title='Any Shell'>
           <code className='db'><b className='no-select'>$ </b>ipfs daemon</code>
           <code className='db'>Initializing daemon...</code>
-          <code className='db'>API server listening on /ip4/127.0.0.1/tcp/5001</code>
+          <code className='db'>RPC API server listening on /ip4/127.0.0.1/tcp/5001</code>
         </Shell>
         { !sameOrigin && (
           <div>
             <Trans i18nKey='notConnected.paragraph3' t={t}>
-              <li className='mb3 mt4'>Is your IPFS API configured to allow <a className='link blue' href='https://github.com/ipfs/ipfs-webui#configure-kubo-rpc-api-cors-headers'>cross-origin (CORS) requests</a>? If not, run these commands and then start your daemon from the terminal:</li>
+              <li className='mb3 mt4'>Is your Kubo RPC API configured to allow <a className='link blue' href='https://github.com/ipfs/ipfs-webui#configure-kubo-rpc-api-cors-headers'>cross-origin (CORS) requests</a>? If not, run these commands and then start your daemon from the terminal:</li>
             </Trans>
             <div className='br1 overflow-hidden'>
               <div className='f7 mb0 sans-serif charcoal pv1 pl2 bg-black-20 flex items-center overflow-x-auto'>
@@ -77,7 +77,7 @@ const IsNotConnected = ({ t, apiUrl, connected, sameOrigin, ipfsApiAddress, doUp
           </div>
         )}
         <Trans i18nKey='notConnected.paragraph4' t={t}>
-          <li className='mt4 mb3'>Is your IPFS API on a port other than 5001? If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom API address</a>, enter it here.</li>
+          <li className='mt4 mb3'>Is your Kubo RPC on a port other than 5001? If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom RPC API address</a>, enter it here.</li>
         </Trans>
         <ApiAddressForm
           t={t}

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -42,7 +42,7 @@ export const SettingsPage = ({
       <title>{t('title')} | IPFS</title>
     </Helmet>
 
-    {/* Enable a full screen loader after updating to a new IPFS API address.
+    {/* Enable a full screen loader after updating to a new Kubo RPC address.
       * Will not show on consequent retries after a failure.
       */}
     { ipfsPendingFirstConnection


### PR DESCRIPTION
### Summary

This PR aims to finish our UX migration from "ipfs daemon" being IPFS, and making it explicitly clear that there is no "IPFS API", but we use "Kubo daemon" and "Kubo RPC API".

I also updated STDOUT example to reflect Kubo 0.30.


### Rationale

Many users are not aware that 99% of their interactions with IPFS depend on Kubo, and if things go wrong, they are not sure what "Kubo RPC" is.

This PR replaces "IPFS API" with "Kubo RPC" to make it more clear what components are at play, and what terms to use when looking for help.


### Preview

> ![2024-09-18_17-55](https://github.com/user-attachments/assets/5cbf2496-d0bb-4d3d-8496-dc57ebbc8f0e)
