### PR TITLE
fix: PDF viewer refreshes when interacting with web UI

### DIFF
--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -116,7 +116,7 @@ const FilesPage = ({
   }
 
   const MainView = ({ t, files, remotePins, pendingPins, failedPins, doExploreUserProvidedPath }) => {
-    if (!files) return (<div/>)
+    if (!files || files.type === 'file') return (<div/>)
 
     if (files.type === 'unknown') {
       const path = files.path
@@ -127,12 +127,6 @@ const FilesPage = ({
             The current link isn't a file, nor a directory. Try to <button className='link blue pointer' onClick={() => doExploreUserProvidedPath(path)}>inspect</button> it instead.
           </Trans>
         </div>
-      )
-    }
-
-    if (files.type === 'file') {
-      return (
-        <FilePreview {...files} onDownload={() => onDownload([files])} />
       )
     }
 
@@ -216,6 +210,8 @@ const FilesPage = ({
 
       <MainView t={t} files={files} remotePins={remotePins} pendingPins={pendingPins} failedPins={failedPins} doExploreUserProvidedPath={doExploreUserProvidedPath}/>
 
+      <Preview files={files} onDownload={() => onDownload([files])} />
+
       <InfoBoxes isRoot={filesPathInfo.isMfs && filesPathInfo.isRoot}
         isCompanion={false}
         filesExist={!!(files && files.content && files.content.length)} />
@@ -246,6 +242,13 @@ const FilesPage = ({
         showProgress />
     </div>
   )
+}
+
+const Preview = ({ files, onDownload }) => {
+  if (files && files.type === 'file') {
+    return (<FilePreview {...files} onDownload={onDownload} />)
+  }
+  return (<div/>)
 }
 
 export default connect(


### PR DESCRIPTION
In Files, the PDF viewer was re-rendering when interacting with web UI.

In [FilesPage.js](https://github.com/ipfs/ipfs-webui/blob/main/src/files/FilesPage.js), `MainView` is defined as a new component inside the `FilesPage` component, so clicking UI elements around the PDF re-renders `MainView` (and since `MainView` contains the logic that shows the file preview component, the preview re-renders). Issue seemed to only affect PDFs.

Fix: creating and using a new file preview component defined outside of `FilePages`. Not sure if this is the cleanest approach, so I'm open to suggestions!

Closes #2145 

https://github.com/user-attachments/assets/853c578d-d843-474a-9548-5314ac607bb9