### PR TITLE
fix: build script doesn't persist stats.json

### DIFF
--- a/config-overrides.js
+++ b/config-overrides.js
@@ -90,13 +90,21 @@ function webpackOverride (config) {
     new webpack.ProvidePlugin({
       process: 'process/browser',
       Buffer: ['buffer', 'Buffer']
-    }),
-    new BundleAnalyzerPlugin({
-      generateStatsFile: true,
-      analyzerMode: 'disabled',
-      openAnalyzer: false
     })
   ])
+
+  /**
+   * NODE_ENV is overridden by react-scripts/react-app-rewired-esm,
+   * so we set BUILD_ENV in the analyze script
+   */
+  if (process.env.BUILD_ENV === 'analyze') {
+    config.plugins.push(
+      new BundleAnalyzerPlugin({
+        analyzerMode: 'server',
+        openAnalyzer: true
+      })
+    )
+  }
 
   config.module.rules = modifyBabelLoaderRuleForBuild(config.module.rules)
   config.module.rules.push({

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "test:e2e": "cross-env REACT_APP_ENV=test npx playwright test -c ./test/e2e",
     "test:build": "cross-env REACT_APP_ENV=test run-s build",
     "test:coverage": "jest --coverage",
-    "analyze": "webpack-bundle-analyzer build/stats.json",
+    "analyze": "cross-env BUILD_ENV=analyze npm run build",
     "eject": "react-scripts eject",
     "storybook": "start-storybook -p 9009",
     "build-storybook": "build-storybook --modern",


### PR DESCRIPTION
fix: analyze script doesn't persist stats.json

Instead of generating a build/stats.json and then using the webpack-bundle-analyzer CLI, we run the server directly via the plugin options if BUILD_ENV=analyze.

Fixes #2289
