### PR TITLE
fix: add lithuanian to languages.json

### DIFF
--- a/src/lib/languages.json
+++ b/src/lib/languages.json
@@ -74,6 +74,11 @@
     "nativeName": "한국어 (韩国)",
     "englishName": "Korean (Korea)"
   },
+  "lt": {
+    "locale": "lt",
+    "nativeName": "Lietuvių",
+    "englishName": "Lithuanian"
+  },
   "nl": {
     "locale": "nl",
     "nativeName": "Nederlands",


### PR DESCRIPTION
Adds `lt` to languages.json so it passes unit tests. The first translations for this language was added in #2291

<img width="613" alt="image" src="https://github.com/user-attachments/assets/439c3c11-bdf7-49ea-bff5-2aba564b44aa">

