### PR TITLE
Do not specify replication factor when pinning - use cluster's default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,6 @@ jobs:
               --basic-auth "${CLUSTER_USER}:${CLUSTER_PASSWORD}" \
               pin add \
               --name "${PIN_NAME}" \
-              --replication-min 1 \
-              --replication-max 3 \
               --wait \
               $PIN_CID
         env:


### PR DESCRIPTION
This was not a good idea when pinning to collab clusters...