### PR TITLE
fix: handle ipfs.files.stat RPC error responses

### DIFF
--- a/src/bundles/notify.js
+++ b/src/bundles/notify.js
@@ -24,6 +24,17 @@ const notify = {
       return { ...state, show: false }
     }
 
+    if (action.type === 'FILES_STAT_FAILED') {
+      return {
+        ...state,
+        show: true,
+        error: true,
+        eventId: 'FILES_EVENT_FAILED',
+        code: action.payload.error.code,
+        msgArgs: { message: action.payload.error.message }
+      }
+    }
+
     if (action.type === 'STATS_FETCH_FAILED') {
       return {
         ...state,


### PR DESCRIPTION
Fixes #2299

- Added error handling for ipfs.files.stat when it returns Type: error
- Shows error notification to user
- Maintains UI functionality with fallback data