### PR TITLE
fix(peers): chrome regression and update ipfs-geoip to v9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "intl-messageformat": "^10.3.3",
         "ip": "^1.1.9",
         "ipfs-css": "^1.4.0",
-        "ipfs-geoip": "^9.1.0",
+        "ipfs-geoip": "^9.2.0",
         "ipfs-provider": "^2.1.0",
         "ipld-explorer-components": "^8.1.3",
         "is-ipfs": "^8.0.1",
@@ -40301,9 +40301,9 @@
       }
     },
     "node_modules/ipfs-geoip": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-9.1.0.tgz",
-      "integrity": "sha512-1hccF+dtVYdnRzMLmoP6QMtLLG5yHHANnsnxfpY3U5jGX+bN7rrsXJiQ9nWtczN/+CAFRoaOU11A53MsoS0Iww==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/ipfs-geoip/-/ipfs-geoip-9.2.0.tgz",
+      "integrity": "sha512-f7lS2YppDVxbyDrcIz1G8QmKBOuFdCxyIDpN03/DF13XjnMnyV2YooFswOv+DBlcS4EMyuHTHn6+UvRf6K2gcg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "intl-messageformat": "^10.3.3",
     "ip": "^1.1.9",
     "ipfs-css": "^1.4.0",
-    "ipfs-geoip": "^9.1.0",
+    "ipfs-geoip": "^9.2.0",
     "ipfs-provider": "^2.1.0",
     "ipld-explorer-components": "^8.1.3",
     "is-ipfs": "^8.0.1",

--- a/src/bundles/peer-locations.js
+++ b/src/bundles/peer-locations.js
@@ -234,6 +234,10 @@ class PeerLocationResolver {
   async findLocations (gatewayUrls, peers) {
     const res = {}
 
+    // Normalize Gateway URLS:
+    // switch localhost to raw IP to avoid subdomain redirect AND avoid Chrome forcing https:// on such redirect
+    gatewayUrls = (Array.isArray(gatewayUrls) ? gatewayUrls : [gatewayUrls]).map(url => url.replace(/localhost:(\d+)/, '127.0.0.1:$1'))
+
     for (const p of this.optimizedPeerSet(peers)) {
       const peerId = p.peer
 


### PR DESCRIPTION
https://github.com/ipfs-shipyard/ipfs-geoip/releases/tag/v9.2.0 updates Peers screen to use dataset from 2025-02-18.

This fixes most of invalid country flags that suggest libp2p is breaking the speed of light ;-)

- [x] CI green 
- [x] confirm manually that flags load ok on Peers screen (in empty browser profile, to avoid cached results)
  - fixed Chrome bug on Peers screen (forcing `https://` on localhost redirect) in https://github.com/ipfs/ipfs-webui/pull/2333/commits/0310932cce5c8f038c5f1d2c29b0a69207070a16