### PR TITLE
fix: add hint about basic http auth for rpc

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Could not connect to the Kubo RPC"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.io)"

--- a/public/locales/fi/app.json
+++ b/public/locales/fi/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Yhdistäminen IPFS-rajapintaan ei onnistunut"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://dweb.link)"

--- a/public/locales/hu/app.json
+++ b/public/locales/hu/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Could not connect to the Kubo RPC"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.io)"

--- a/public/locales/ja-JP/app.json
+++ b/public/locales/ja-JP/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Could not connect to the Kubo RPC"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.io)"

--- a/public/locales/ko-KR/app.json
+++ b/public/locales/ko-KR/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Could not connect to the IPFS API"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://dweb.link)"

--- a/public/locales/ur/app.json
+++ b/public/locales/ur/app.json
@@ -46,7 +46,7 @@
     "couldNotConnect": "Could not connect to the Kubo RPC"
   },
   "apiAddressForm": {
-    "placeholder": "Enter a URL (http://127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
+    "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.io)"


### PR DESCRIPTION
## Context
This PR expands on https://github.com/ipfs/ipfs-docs/pull/2000 and aims to provide a hint that you can pass basic HTTP auth credentials in the webui. 

