### PR TITLE
refactor: remove unused exports identified by ts-unused-exports

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -66,7 +66,7 @@ const cumulativeSize = async (ipfs, cidOrPath) => {
  * @returns {string}
  */
 // TODO: use sth else
-export const realMfsPath = (path) => {
+const realMfsPath = (path) => {
   if (path.startsWith('/files')) {
     return path.substring('/files'.length) || '/'
   }

--- a/src/bundles/files/consts.js
+++ b/src/bundles/files/consts.js
@@ -72,7 +72,7 @@ export const DEFAULT_STATE = {
   failed: []
 }
 
-export const cliCmdKeys = {
+const cliCmdKeys = {
   DOWNLOAD_OBJECT_COMMAND: 'downloadObjectCommand',
   REMOVE_FILE_FROM_IPFS: 'removeFileFromIpfs',
   UPDATE_IPFS_CONFIG: 'updateIpfsConfig',
@@ -88,11 +88,11 @@ export const cliCmdKeys = {
   DOWNLOAD_CAR_COMMAND: 'downloadCarCommand'
 }
 
-export const cliCmdPrefixes = {
+const cliCmdPrefixes = {
   PIN_OBJECT: 'ipfs pin'
 }
 
-export const cliCommandList = {
+const cliCommandList = {
   [cliCmdKeys.UPDATE_IPFS_CONFIG]: () => 'ipfs config replace <path-to-settings.json>',
   /**
    * @param {string} filePath

--- a/src/bundles/files/index.js
+++ b/src/bundles/files/index.js
@@ -3,9 +3,9 @@ import { DEFAULT_STATE, ACTIONS, SORTING } from './consts.js'
 import selectors from './selectors.js'
 import actions from './actions.js'
 
-export { ACTIONS }
+{ ACTIONS }
 
-export const sorts = SORTING
+const sorts = SORTING
 
 /**
  * @typedef {import('./protocol').Model} Model

--- a/src/bundles/files/protocol.ts
+++ b/src/bundles/files/protocol.ts
@@ -3,11 +3,11 @@ import { Perform, Spawn } from "../task"
 
 export type { Perform, Spawn }
 
-export type Pin = {
+type Pin = {
   cid: CID
 }
 
-export type Model = {
+type Model = {
   pageContent: null | PageContent
   pins: string[]
   sorting: Sorting
@@ -18,42 +18,38 @@ export type Model = {
   failed: FailedJob[]
 }
 
-
-export interface JobInfo {
+interface JobInfo {
   type: Message['type']
   id: Symbol
   start: number
 }
 
-
-export interface PendingJob<M, I> extends JobInfo {
+interface PendingJob<M, I> extends JobInfo {
   status: 'Pending'
   init: I
   message?: M
 }
 
-
-export interface FailedJob extends JobInfo {
+interface FailedJob extends JobInfo {
   status: 'Failed'
   error: Error
   end: number
 }
 
-export interface FinishedJob<T> extends JobInfo {
+interface FinishedJob<T> extends JobInfo {
   status: 'Done'
   value: T
   end: number
 }
 
-
-export type Sorting = {
+type Sorting = {
   by: SortBy,
   asc: boolean
 }
 
-export type SortBy = 'name' | 'size'
+type SortBy = 'name' | 'size'
 
-export type Message =
+type Message =
   | { type: 'FILES_CLEAR_ALL' }
   | { type: 'FILES_DISMISS_ERRORS' }
   | { type: 'FILES_UPDATE_SORT', payload: Sorting }
@@ -73,16 +69,16 @@ export type Message =
   | Perform<'FILES_SIZE_GET', Error, { size: number }, void>
   | Perform<'FILES_PINS_SIZE_GET', Error, { pinsSize: number, numberOfPins: number }, void>
 
-export type MakeDir = Perform<'FILES_MAKEDIR', Error, void, void>
-export type WriteProgress = { paths: string[], progress: number }
-export type Write = Spawn<'FILES_WRITE', WriteProgress, Error, void, void>
-export type AddByPath = Perform<'FILES_ADDBYPATH', Error, void, void>
-export type BulkCidImport = Perform<'FILES_BULK_CID_IMPORT', Error, void, void>
-export type Move = Perform<'FILES_MOVE', Error, void, void>
-export type Delete = Perform<'FILES_DELETE', Error, void, void>
-export type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
+type MakeDir = Perform<'FILES_MAKEDIR', Error, void, void>
+type WriteProgress = { paths: string[], progress: number }
+type Write = Spawn<'FILES_WRITE', WriteProgress, Error, void, void>
+type AddByPath = Perform<'FILES_ADDBYPATH', Error, void, void>
+type BulkCidImport = Perform<'FILES_BULK_CID_IMPORT', Error, void, void>
+type Move = Perform<'FILES_MOVE', Error, void, void>
+type Delete = Perform<'FILES_DELETE', Error, void, void>
+type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
 
-export type FileDownload = {
+type FileDownload = {
   url: string
   filename: string
 }
@@ -101,7 +97,7 @@ type FileStat = {
   isParent: boolean | void
 }
 
-export type PageContent =
+type PageContent =
   | UnknownContent
   | FileContent
   | DirectoryContent
@@ -125,7 +121,7 @@ type FileContent = {
   pinned: boolean
 }
 
-export type DirectoryContent = {
+type DirectoryContent = {
   type: 'directory',
   fetched: Time,
   path: string,
@@ -135,15 +131,13 @@ export type DirectoryContent = {
   upper: void | FileStat,
 }
 
-export type Job<K, P, X, T> = {
+type Job<K, P, X, T> = {
   type: K,
   job: JobState<P, X, T>
 }
 
-export type JobState<P, X, T> =
+type JobState<P, X, T> =
   | { status: 'Idle', id: Symbol }
   | { status: 'Active', id: Symbol, state: P }
   | { status: 'Failed', id: Symbol, error: X }
   | { status: 'Done', id: Symbol, value: T }
-
-

--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -160,7 +160,7 @@ const readAPIAddressSetting = () => {
  * @param {string|object} value
  * @returns {boolean}
  */
-export const checkValidAPIAddress = (value) => {
+const checkValidAPIAddress = (value) => {
   return asAPIOptions(value) != null
 }
 

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -20,7 +20,7 @@ import filesize from 'filesize'
  * @param {ExtendedFile[]} files
  * @returns {FileStream[]}
  */
-export function normalizeFiles (files) {
+function normalizeFiles (files) {
   const streams = []
 
   for (const file of files) {
@@ -56,7 +56,7 @@ function getDownloadURL (type, name, cid, gatewayUrl) {
  * @param {IPFSService} ipfs
  * @returns {Promise<CID>}
  */
-export async function makeCIDFromFiles (files, ipfs) {
+async function makeCIDFromFiles (files, ipfs) {
   // Note: we don't use 'object patch' here, it was deprecated.
   // We are using MFS for creating CID of an ephemeral directory
   // because it handles HAMT-sharding of big directories automatically
@@ -157,7 +157,7 @@ export async function getCarLink (files, gatewayUrl, ipfs) {
  * @param {object} opts format customization
  * @returns {string} human-readable size
  */
-export function humanSize (size, opts) {
+function humanSize (size, opts) {
   if (typeof size === 'undefined' || size === null) return 'N/A'
   return filesize(size || 0, {
     // base-2 byte units (GiB, MiB, KiB) to remove any ambiguity

--- a/src/lib/hofs/functions.js
+++ b/src/lib/hofs/functions.js
@@ -9,7 +9,7 @@ import { isFunction, isNumber } from '../guards.js'
  * @param {(...args: A[]) => R} fn
  * @returns {(...args: A[]) => void | R}
  */
-export const after = (fn, times) => {
+const after = (fn, times) => {
   isFunction(fn) && isNumber(times)
   let counter = 0
   /**
@@ -30,7 +30,7 @@ export const after = (fn, times) => {
  * @param {(...args: A[]) => R} fn
  * @returns {(...args: A[]) => R}
  */
-export const once = (fn) => {
+const once = (fn) => {
   isFunction(fn)
   let called = false
   /**
@@ -61,7 +61,7 @@ export const once = (fn) => {
  * @param {boolean} [options.leading]
  * @returns {(...args: A[]) => void}
  */
-export const debounce = (fn, delay, { leading = false } = {}) => {
+const debounce = (fn, delay, { leading = false } = {}) => {
   isFunction(fn) && isNumber(delay)
   /**
    * @type {NodeJS.Timeout}

--- a/src/lib/sort.js
+++ b/src/lib/sort.js
@@ -26,7 +26,7 @@ export function sortBySize (dir = 1) {
  * @param {1|-1} dir - sorting direction, 1 for ascending or -1 for descending
  * @returns {(a:T, b:T) => number}
  */
-export function sortByProperty (property, dir = 1) {
+function sortByProperty (property, dir = 1) {
   // @ts-ignore - `a` and `b` may not be numbers
   return ({ [property]: a }, { [property]: b }) => (a == null) - (b == null) || dir * +(a > b) || dir * -(a < b)
 }


### PR DESCRIPTION
This PR removes unused exports that were identified by the `ts-unused-exports` tool. Removing these unused exports helps in code cleanup, reduces bundle size, and improves maintainability by removing code that isn't being used elsewhere in the project. #2036 

Changes:
- Removed unused exports from `/src/bundles/files/protocol.ts` (kept only re-exports of `Perform`, `Spawn`)
- Removed unused export `realMfsPath` from `/src/bundles/files/actions.js`
- Removed unused exports (`cliCmdKeys`, `cliCmdPrefixes`, `cliCommandList`) from `/src/bundles/files/consts.js`
- Removed unused exports (`ACTIONS`, `sorts`, `default`) from `/src/bundles/files/index.js`
- Removed unused default exports from multiple bundle files
- Removed unused export `checkValidAPIAddress` from `/src/bundles/ipfs-provider.js` (kept default export)
- Removed unused export `sortByProperty` from `/src/lib/sort.js`
- Removed unused exports (`normalizeFiles`, `makeCIDFromFiles`, `humanSize`) from `/src/lib/files.js`
- Removed unused exports (`after`, `once`, `debounce`) from `/src/lib/hofs/functions.js`

All functions are retained for internal use but are no longer exported.