### PR TITLE
chore: remove web3.storage and Scaleway

### DIFF
--- a/src/constants/pinning.js
+++ b/src/constants/pinning.js
@@ -39,22 +39,10 @@ const pinningServiceTemplates = [
     visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
   },
   {
-    name: 'Web3.Storage',
-    icon: 'https://dweb.link/ipfs/bafybeiaqsdwuwemchbofzok4cq7cuvotfs6bgickxdqr6f7hdt7a64cwwa/Web3.Storage-logo.svg',
-    apiEndpoint: 'https://api.web3.storage',
-    visitServiceUrl: 'https://web3.storage/docs/how-tos/pinning-services-api/'
-  },
-  {
     name: '4EVERLAND',
     icon: 'https://dweb.link/ipfs/bafkreie4mg2rmoe6fzct4rpwd2d4nuok3yx2mew567nu3s5bfnnmlb65ei?filename=4everland-logo.svg',
     apiEndpoint: 'https://api.4everland.dev',
     visitServiceUrl: 'https://docs.4everland.org/storage/4ever-pin/pinning-services-api'
-  },
-  {
-    name: 'Scaleway',
-    icon: 'https://dweb.link/ipfs/QmTM7RtYsuJFoV7y3Ec1WdGTW8knKrjwbY6ByTGsJN6TYw?filename=scaleway.svg',
-    apiEndpoint: 'https://<your-volume-region-code>.ipfs.labs.scw.cloud/<your-volume-id>/',
-    visitServiceUrl: 'https://www.scaleway.com/en/docs/labs/ipfs-pinning/reference-content/install-ipfs-desktop/'
   }
 ].map((service) => {
   try {


### PR DESCRIPTION
This PR removes Web3.Storage and Scaleway from WebUI and IPFS Desktop.
Remote Pinning APIs endpoints no longer work and docs return 404, and having those only confuse users of Kubo and IPFS Desktop.

> ![image](https://github.com/user-attachments/assets/7185bbeb-b69a-4381-b6bf-2314aae5f1b6)


cc for visibility:
- https://github.com/ipfs/ipfs-webui/pull/2026  @alanshaw @vasco-santos
- https://github.com/ipfs/ipfs-webui/pull/2132 https://github.com/ipfs/ipfs-webui/pull/2132 @OnsagerHe @vmscw 
