### PR TITLE
fix: refresh stale multiaddrs on the Status page

### DIFF
--- a/src/bundles/identity.js
+++ b/src/bundles/identity.js
@@ -1,12 +1,15 @@
 import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
 
+// Matches APP_IDLE and peer bandwidth update intervals
+export const IDENTITY_REFRESH_INTERVAL = 5000
+
 const bundle = createAsyncResourceBundle({
   name: 'identity',
   actionBaseType: 'IDENTITY',
   getPromise: ({ getIpfs }) => getIpfs().id().catch((err) => {
     console.error('Failed to get identity', err)
   }),
-  staleAfter: Infinity,
+  staleAfter: IDENTITY_REFRESH_INTERVAL,
   persist: false,
   checkIfOnline: false
 })

--- a/src/status/StatusPage.js
+++ b/src/status/StatusPage.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Helmet } from 'react-helmet'
 import { withTranslation, Trans } from 'react-i18next'
 import { connect } from 'redux-bundler-react'
@@ -15,6 +15,7 @@ import AnalyticsBanner from '../components/analytics-banner/AnalyticsBanner.js'
 import { statusTour } from '../lib/tours.js'
 import { getJoyrideLocales } from '../helpers/i8n.js'
 import withTour from '../components/tour/withTour.js'
+import { IDENTITY_REFRESH_INTERVAL } from '../bundles/identity.js'
 
 const StatusPage = ({
   t,
@@ -26,8 +27,27 @@ const StatusPage = ({
   doToggleShowAnalyticsBanner,
   toursEnabled,
   handleJoyrideCallback,
-  nodeBandwidthEnabled
+  nodeBandwidthEnabled,
+  doFetchIdentity,
+  isNodeInfoOpen
 }) => {
+  // Refresh identity when page mounts
+  useEffect(() => {
+    if (ipfsConnected) {
+      doFetchIdentity()
+    }
+  }, [ipfsConnected, doFetchIdentity])
+
+  // Refresh identity when Advanced section is open
+  useEffect(() => {
+    if (ipfsConnected && isNodeInfoOpen) {
+      const intervalId = setInterval(() => {
+        doFetchIdentity()
+      }, IDENTITY_REFRESH_INTERVAL)
+
+      return () => clearInterval(intervalId)
+    }
+  }, [ipfsConnected, isNodeInfoOpen, doFetchIdentity])
   return (
     <div data-id='StatusPage' className='mw9 center'>
       <Helmet>
@@ -95,8 +115,10 @@ export default connect(
   'selectShowAnalyticsBanner',
   'selectShowAnalyticsComponents',
   'selectToursEnabled',
+  'selectIsNodeInfoOpen',
   'doEnableAnalytics',
   'doDisableAnalytics',
   'doToggleShowAnalyticsBanner',
+  'doFetchIdentity',
   withTour(withTranslation('status')(StatusPage))
 )


### PR DESCRIPTION
This PR closes #1964 and ensures addresses added by AutoTLS/RelayV2 are updated and visible in WebUI correctly:

- one-time update when Status Page is opened
- update addresses every 5s  if addrs section is expanded


This way we call `/ipfs/v0/id` only when UI actually needs it:
> <img width="1278" height="1070" alt="2025-07-15_21-33" src="https://github.com/user-attachments/assets/46c3d1e5-669c-4488-8437-3af505b2b0b2" />
