### PR TITLE
feat: add async provide on share/copy/pin/ipns

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -11,7 +11,8 @@ module.exports = {
   // ignore .ts files because it fails to parse it.
   ignorePatterns: 'src/**/*.ts',
   rules: {
-    'react/prop-types': [0, { ignore: ['className'], customValidators: [], skipUndeclared: true }] // TODO: set this rule to error when all issues are resolved.
+    'react/prop-types': [0, { ignore: ['className'], customValidators: [], skipUndeclared: true }], // TODO: set this rule to error when all issues are resolved.
+    'no-void': 'off'
   },
   overrides: [
     {

--- a/src/bundles/files/consts.js
+++ b/src/bundles/files/consts.js
@@ -60,6 +60,9 @@ export const IGNORED_FILES = [
   'desktop.ini'
 ]
 
+// Maximum length for DNS labels (used for subdomain gateway CID validation)
+export const DNS_LABEL_MAX_LENGTH = 63
+
 /** @type {Model} */
 export const DEFAULT_STATE = {
   pageContent: null,

--- a/src/bundles/files/utils.js
+++ b/src/bundles/files/utils.js
@@ -1,12 +1,14 @@
 import { sortByName, sortBySize } from '../../lib/sort.js'
 import { IS_MAC, SORTING } from './consts.js'
 import * as Task from '../task.js'
+import { debouncedProvide } from '../../lib/files.js'
 
 /**
  * @typedef {import('ipfs').IPFSService} IPFSService
  * @typedef {import('../../lib/files').FileStream} FileStream
  * @typedef {import('./actions').Ext} Ext
  * @typedef {import('./actions').Extra} Extra
+ * @typedef {import('multiformats/cid').CID} CID
  */
 
 /**
@@ -314,5 +316,21 @@ export const ensureMFS = (store) => {
   const info = store.selectFilesPathInfo()
   if (!info || !info.isMfs) {
     throw new Error('Unable to perform task if not in MFS')
+  }
+}
+
+/**
+ * Dispatches an async provide operation for a CID.
+ *
+ * @param {CID|null|undefined} cid - The CID to provide
+ * @param {IPFSService} ipfs - The IPFS service instance
+ * @param {string} context - Context for logging
+ */
+export const dispatchAsyncProvide = (cid, ipfs, context) => {
+  if (cid) {
+    console.debug(`[${context}] Dispatching one-time ad-hoc provide for root CID ${cid.toString()} (non-recursive) for improved performance when sharing today`)
+    debouncedProvide(cid, ipfs).catch((error) => {
+      console.error(`[${context}] debouncedProvide failed:`, error)
+    })
   }
 }

--- a/src/bundles/files/utils.js
+++ b/src/bundles/files/utils.js
@@ -327,9 +327,9 @@ export const ensureMFS = (store) => {
  * @param {string} context - Context for logging
  */
 export const dispatchAsyncProvide = (cid, ipfs, context) => {
-  if (cid) {
+  if (cid != null) {
     console.debug(`[${context}] Dispatching one-time ad-hoc provide for root CID ${cid.toString()} (non-recursive) for improved performance when sharing today`)
-    debouncedProvide(cid, ipfs).catch((error) => {
+    void debouncedProvide(cid, ipfs).catch((error) => {
       console.error(`[${context}] debouncedProvide failed:`, error)
     })
   }

--- a/src/bundles/ipns.js
+++ b/src/bundles/ipns.js
@@ -1,5 +1,6 @@
 import all from 'it-all'
 import { readSetting, writeSetting } from './local-storage.js'
+import { dispatchAsyncProvide } from './files/utils.js'
 
 const init = () => ({
   keys: [],
@@ -61,6 +62,9 @@ const ipnsBundle = {
   doPublishIpnsKey: (cid, key) => async ({ getIpfs, store }) => {
     const ipfs = getIpfs()
     await ipfs.name.publish(cid, { key })
+
+    // Trigger background provide operation for the published CID
+    dispatchAsyncProvide(cid, ipfs, 'IPNS')
   },
 
   doUpdateExpectedPublishTime: (time) => async ({ store, dispatch }) => {

--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -5,6 +5,7 @@ import { CID } from 'multiformats/cid'
 import all from 'it-all'
 
 import { readSetting, writeSetting } from './local-storage.js'
+import { dispatchAsyncProvide } from './files/utils.js'
 
 // This bundle leverages createCacheBundle and persistActions for
 // the persistence layer that keeps pins in IndexDB store
@@ -361,6 +362,9 @@ const pinningBundle = {
         if (pinLocally) {
           await ipfs.pin.add(cid)
           dispatch({ type: 'IPFS_PIN_SUCCEED', msgArgs })
+
+          // Trigger background provide operation for pinned CID
+          dispatchAsyncProvide(cid, ipfs, 'PIN')
         } else {
           await ipfs.pin.rm(cid)
           dispatch({ type: 'IPFS_UNPIN_SUCCEED', msgArgs })

--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -28,7 +28,7 @@ import Checkbox from '../components/checkbox/Checkbox.js'
 const FilesPage = ({
   doFetchPinningServices, doFilesFetch, doPinsFetch, doFilesSizeGet, doFilesDownloadLink, doFilesDownloadCarLink, doFilesWrite, doAddCarFile, doFilesBulkCidImport, doFilesAddPath, doUpdateHash,
   doFilesUpdateSorting, doFilesNavigateTo, doFilesMove, doSetCliOptions, doFetchRemotePins, remotePins, pendingPins, failedPins,
-  ipfsProvider, ipfsConnected, doFilesMakeDir, doFilesShareLink, doFilesDelete, doSetPinning, onRemotePinClick, doPublishIpnsKey,
+  ipfsProvider, ipfsConnected, doFilesMakeDir, doFilesShareLink, doFilesCopyCidProvide, doFilesDelete, doSetPinning, onRemotePinClick, doPublishIpnsKey,
   files, filesPathInfo, pinningServices, toursEnabled, handleJoyrideCallback, isCliTutorModeEnabled, cliOptions, t
 }) => {
   const { doExploreUserProvidedPath } = useExplore()
@@ -291,6 +291,7 @@ const FilesPage = ({
         onDownloadCar={() => onDownloadCar([contextMenu.file])}
         onPinning={() => showModal(PINNING, [contextMenu.file])}
         onPublish={() => showModal(PUBLISH, [contextMenu.file])}
+        onCopyCid={(cid) => doFilesCopyCidProvide(cid)}
         isCliTutorModeEnabled={isCliTutorModeEnabled}
         onCliTutorMode={() => showModal(CLI_TUTOR_MODE, [contextMenu.file])}
         doSetCliOptions={doSetCliOptions}
@@ -416,6 +417,7 @@ export default connect(
   'doFilesMove',
   'doFilesMakeDir',
   'doFilesShareLink',
+  'doFilesCopyCidProvide',
   'doFilesDelete',
   'doFilesAddPath',
   'doAddCarFile',

--- a/src/files/context-menu/ContextMenu.js
+++ b/src/files/context-menu/ContextMenu.js
@@ -45,7 +45,7 @@ class ContextMenu extends React.Component {
 
   render () {
     const {
-      t, onRename, onRemove, onDownload, onInspect, onShare, onDownloadCar, onPublish,
+      t, onRename, onRemove, onDownload, onInspect, onShare, onDownloadCar, onPublish, onCopyCid,
       translateX, translateY, className, isMfs, isUnknown, isCliTutorModeEnabled
     } = this.props
     return (
@@ -65,7 +65,12 @@ class ContextMenu extends React.Component {
               {t('actions.share')}
             </Option>
           }
-          <CopyToClipboard text={String(this.props.cid)} onCopy={this.props.handleClick}>
+          <CopyToClipboard text={String(this.props.cid)} onCopy={() => {
+            this.props.handleClick()
+            if (onCopyCid) {
+              onCopyCid(this.props.cid)
+            }
+          }}>
             <Option>
               <StrokeCopy className='w2 mr2 fill-aqua' />
               {t('actions.copyHash')}
@@ -140,6 +145,7 @@ ContextMenu.propTypes = {
   onInspect: PropTypes.func,
   onShare: PropTypes.func,
   onPublish: PropTypes.func,
+  onCopyCid: PropTypes.func,
   className: PropTypes.string,
   t: PropTypes.func.isRequired,
   tReady: PropTypes.bool.isRequired,

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -99,7 +99,7 @@ export async function getDownloadLink (files, gatewayUrl, ipfs) {
  * @param {string} gatewayUrl - The URL of the default IPFS gateway.
  * @param {string} subdomainGatewayUrl - The URL of the subdomain gateway.
  * @param {IPFSService} ipfs - The IPFS service instance for interacting with the IPFS network.
- * @returns {Promise<string>} - A promise that resolves to the shareable link for the provided files.
+ * @returns {Promise<{link: string, cid: CID}>} - A promise that resolves to an object containing the shareable link and root CID.
  */
 export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, ipfs) {
   let cid
@@ -129,7 +129,7 @@ export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, 
     shareableLink = `${gatewayUrl}/ipfs/${cid}${filename || ''}`
   }
 
-  return shareableLink
+  return { link: shareableLink, cid }
 }
 
 /**
@@ -150,6 +150,46 @@ export async function getCarLink (files, gatewayUrl, ipfs) {
   }
 
   return `${gatewayUrl}/ipfs/${cid}?format=car&filename=${filename || cid}.car`
+}
+
+// Cache for tracking provide operations to avoid spamming the network
+const provideCache = new Map()
+const PROVIDE_DEBOUNCE_TIME = 15 * 60 * 1000 // 15 minutes in milliseconds
+
+/**
+ * Debounced function to provide a CID to the IPFS DHT network.
+ *
+ * @param {CID} cid - The CID to provide to the network
+ * @param {IPFSService} ipfs - The IPFS service instance
+ */
+export async function debouncedProvide (cid, ipfs) {
+  const cidStr = cid.toString()
+  const now = Date.now()
+  const lastProvideTime = provideCache.get(cidStr)
+
+  if (lastProvideTime && (now - lastProvideTime) < PROVIDE_DEBOUNCE_TIME) {
+    return
+  }
+
+  try {
+    // @ts-ignore - ipfs is actually a KuboRPCClient with routing API
+    const provideEvents = ipfs.routing.provide(cid, { recursive: false })
+
+    for await (const event of provideEvents) {
+      console.debug(`[PROVIDE] ${cidStr}:`, event)
+    }
+
+    provideCache.set(cidStr, now)
+
+    // Clean up old cache entries
+    for (const [cachedCid, timestamp] of provideCache.entries()) {
+      if ((now - timestamp) > PROVIDE_DEBOUNCE_TIME) {
+        provideCache.delete(cachedCid)
+      }
+    }
+  } catch (error) {
+    console.error(`[PROVIDE] Failed for CID ${cidStr}:`, error)
+  }
 }
 
 /**

--- a/src/lib/files.test.js
+++ b/src/lib/files.test.js
@@ -262,10 +262,11 @@ it('should get a subdomain gateway url', async () => {
   const files = [file]
 
   const url = new URL(DEFAULT_SUBDOMAIN_GATEWAY)
-  const shareableLink = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
+  const { link: shareableLink, cid } = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
   const base32Cid = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
   const rightShareableLink = `${url.protocol}//${base32Cid}.ipfs.${url.host}`
   expect(shareableLink).toBe(rightShareableLink)
+  expect(cid).toBeDefined()
 })
 
 it('should get a path gateway url', async () => {
@@ -279,6 +280,7 @@ it('should get a path gateway url', async () => {
   }
   const files = [file]
 
-  const res = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
+  const { link: res, cid } = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
   expect(res).toBe(DEFAULT_PATH_GATEWAY + '/ipfs/' + veryLongCidv1)
+  expect(cid).toBeDefined()
 })


### PR DESCRIPTION
This PR dispatches one-time extra announce of the root CID when sharing, copying CIDs, pinning, or publishing to IPNS.

## Rationale

Providing this CID costs us virtually nothing, but will improve performance when content is accessed by others shortly after these operations by ensuring we are as close to the desired number of Amino DHT peers with provider records as possible, and also that there ARE provider records for the root CID in the DHT in the first place.

The latter especially helps desktop users, who may share a CID that has not been provided yet due to the node being offline for a while and starting IPFS Desktop recently, with Kubo having many CIDs to announce.