### PR TITLE
fix: eslint doesnt check build folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 !.storybook
+build

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -8,8 +8,6 @@ module.exports = {
   },
   extends: ['react-app', 'standard', 'plugin:jsx-a11y/recommended'],
   plugins: ['jsx-a11y', 'storybook', 'import'],
-  // ignore .ts files because it fails to parse it.
-  ignorePatterns: 'src/**/*.ts',
   rules: {
     'react/prop-types': [0, { ignore: ['className'], customValidators: [], skipUndeclared: true }] // TODO: set this rule to error when all issues are resolved.
   },

--- a/src/bundles/files/protocol.ts
+++ b/src/bundles/files/protocol.ts
@@ -1,90 +1,10 @@
 import type { CID } from 'multiformats/cid'
-import { Perform, Spawn } from "../task"
+import { Perform, Spawn } from '../task'
 
 export type { Perform, Spawn }
 
 export type Pin = {
   cid: CID
-}
-
-export type Model = {
-  pageContent: null | PageContent
-  pins: string[]
-  sorting: Sorting
-  mfsSize: number
-
-  pending: PendingJob<any, any>[]
-  finished: FinishedJob<any>[]
-  failed: FailedJob[]
-}
-
-
-export interface JobInfo {
-  type: Message['type']
-  id: Symbol
-  start: number
-}
-
-
-export interface PendingJob<M, I> extends JobInfo {
-  status: 'Pending'
-  init: I
-  message?: M
-}
-
-
-export interface FailedJob extends JobInfo {
-  status: 'Failed'
-  error: Error
-  end: number
-}
-
-export interface FinishedJob<T> extends JobInfo {
-  status: 'Done'
-  value: T
-  end: number
-}
-
-
-export type Sorting = {
-  by: SortBy,
-  asc: boolean
-}
-
-export type SortBy = 'name' | 'size'
-
-export type Message =
-  | { type: 'FILES_CLEAR_ALL' }
-  | { type: 'FILES_DISMISS_ERRORS' }
-  | { type: 'FILES_UPDATE_SORT', payload: Sorting }
-  | Perform<'FILES_FETCH', Error, PageContent, void>
-  | MakeDir
-  | Delete
-  | Move
-  | Write
-  | AddByPath
-  | BulkCidImport
-  | DownloadLink
-  | Perform<'FILES_SHARE_LINK', Error, string, void>
-  | Perform<'FILES_COPY', Error, void, void>
-  | Perform<'FILES_PIN_ADD', Error, Pin[], void>
-  | Perform<'FILES_PIN_REMOVE', Error, Pin[], void>
-  | Perform<'FILES_PIN_LIST', Error, { pins: CID[] }, void>
-  | Perform<'FILES_SIZE_GET', Error, { size: number }, void>
-  | Perform<'FILES_PINS_SIZE_GET', Error, { pinsSize: number, numberOfPins: number }, void>
-
-export type MakeDir = Perform<'FILES_MAKEDIR', Error, void, void>
-export type WriteProgress = { paths: string[], progress: number }
-export type Write = Spawn<'FILES_WRITE', WriteProgress, Error, void, void>
-export type AddByPath = Perform<'FILES_ADDBYPATH', Error, void, void>
-export type BulkCidImport = Perform<'FILES_BULK_CID_IMPORT', Error, void, void>
-export type Move = Perform<'FILES_MOVE', Error, void, void>
-export type Delete = Perform<'FILES_DELETE', Error, void, void>
-export type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
-
-export type FileDownload = {
-  url: string
-  filename: string
 }
 
 type FileType = 'directory' | 'file' | 'unknown'
@@ -100,11 +20,6 @@ type FileStat = {
   pinned: boolean
   isParent: boolean | void
 }
-
-export type PageContent =
-  | UnknownContent
-  | FileContent
-  | DirectoryContent
 
 type UnknownContent = {
   type: 'unknown',
@@ -135,9 +50,83 @@ export type DirectoryContent = {
   upper: void | FileStat,
 }
 
-export type Job<K, P, X, T> = {
-  type: K,
-  job: JobState<P, X, T>
+export type PageContent =
+  | UnknownContent
+  | FileContent
+  | DirectoryContent
+
+export type SortBy = 'name' | 'size'
+
+export type Sorting = {
+  by: SortBy,
+  asc: boolean
+}
+
+export type MakeDir = Perform<'FILES_MAKEDIR', Error, void, void>
+export type WriteProgress = { paths: string[], progress: number }
+export type Write = Spawn<'FILES_WRITE', WriteProgress, Error, void, void>
+export type AddByPath = Perform<'FILES_ADDBYPATH', Error, void, void>
+export type BulkCidImport = Perform<'FILES_BULK_CID_IMPORT', Error, void, void>
+export type Move = Perform<'FILES_MOVE', Error, void, void>
+export type Delete = Perform<'FILES_DELETE', Error, void, void>
+export type FileDownload = {
+  url: string
+  filename: string
+}
+export type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
+
+export type Message =
+  | { type: 'FILES_CLEAR_ALL' }
+  | { type: 'FILES_DISMISS_ERRORS' }
+  | { type: 'FILES_UPDATE_SORT', payload: Sorting }
+  | Perform<'FILES_FETCH', Error, PageContent, void>
+  | MakeDir
+  | Delete
+  | Move
+  | Write
+  | AddByPath
+  | BulkCidImport
+  | DownloadLink
+  | Perform<'FILES_SHARE_LINK', Error, string, void>
+  | Perform<'FILES_COPY', Error, void, void>
+  | Perform<'FILES_PIN_ADD', Error, Pin[], void>
+  | Perform<'FILES_PIN_REMOVE', Error, Pin[], void>
+  | Perform<'FILES_PIN_LIST', Error, { pins: CID[] }, void>
+  | Perform<'FILES_SIZE_GET', Error, { size: number }, void>
+  | Perform<'FILES_PINS_SIZE_GET', Error, { pinsSize: number, numberOfPins: number }, void>
+
+export interface JobInfo {
+  type: Message['type']
+  id: Symbol
+  start: number
+}
+
+export interface PendingJob<M, I> extends JobInfo {
+  status: 'Pending'
+  init: I
+  message?: M
+}
+
+export interface FailedJob extends JobInfo {
+  status: 'Failed'
+  error: Error
+  end: number
+}
+
+export interface FinishedJob<T> extends JobInfo {
+  status: 'Done'
+  value: T
+  end: number
+}
+export type Model = {
+  pageContent: null | PageContent
+  pins: string[]
+  sorting: Sorting
+  mfsSize: number
+
+  pending: PendingJob<any, any>[]
+  finished: FinishedJob<any>[]
+  failed: FailedJob[]
 }
 
 export type JobState<P, X, T> =
@@ -146,4 +135,7 @@ export type JobState<P, X, T> =
   | { status: 'Failed', id: Symbol, error: X }
   | { status: 'Done', id: Symbol, value: T }
 
-
+export type Job<K, P, X, T> = {
+  type: K,
+  job: JobState<P, X, T>
+}


### PR DESCRIPTION
FYI that eslint was passing in CI because it runs before build, but when running locally i was getting hundreds of thousands of errors.. debugging with `DEBUG=eslint:cli-engine npm run eslint` showed that the build folder was being checked. when I removed that, it started succeeding again.

Also removed the ignoring of .ts files in the `.eslintrc.cjs` file