### PR TITLE
fix: reference to `global` in browser environment

### DIFF
--- a/src/components/box/Box.js
+++ b/src/components/box/Box.js
@@ -9,7 +9,7 @@ export const Box = ({
 }) => {
   return (
     <section className={className} style={{ background: '#fbfbfb', ...style }}>
-      <ErrorBoundary resetKeys={[global.location.pathname]}>
+      <ErrorBoundary resetKeys={[globalThis.location?.pathname || '']}>
         {children}
       </ErrorBoundary>
     </section>


### PR DESCRIPTION
replaced `global.location.pathname` with `window.location.pathname` since `global` is only available in Node.js.
this resolves the runtime error in the browser and ensures correct path handling in the React app.
