### PR TITLE
fix: prevent redirect when navigating to retrieval-check

### DIFF
--- a/src/diagnostics/diagnostics-content.tsx
+++ b/src/diagnostics/diagnostics-content.tsx
@@ -64,10 +64,15 @@ const DiagnosticsContent: React.FC<DiagnosticsContentProps> = () => {
 
   // Redirect from /diagnostics or /diagnostics/ to /diagnostics/logs
   useEffect(() => {
-    if (path === '' || path === '/') {
+    // Check if we're still loading route info
+    if (!routeInfo) return
+
+    // Only redirect from true root paths
+    const isRootDiagnostics = routeInfo.url === '/diagnostics' || routeInfo.url === '/diagnostics/'
+    if (isRootDiagnostics && (path === '' || path === '/')) {
       window.location.replace('#/diagnostics/logs')
     }
-  }, [path])
+  }, [path, routeInfo])
 
   const isMounted = useRef(false)
   useEffect(() => {


### PR DESCRIPTION
The diagnostics page was redirecting to /logs when clicking "Check Retrieval" from the Files context menu. This happened because the redirect logic fired too early, before the full route was available.

Fixed by checking the complete URL path before redirecting.