### PR TITLE
feat(diagnostics/logs): include extended details

### DIFF
--- a/public/locales/en/diagnostics.json
+++ b/public/locales/en/diagnostics.json
@@ -47,7 +47,10 @@
     "autocomplete": {
       "globalLevel": "Global level",
       "subsystem": "Subsystem",
-      "level": "Log level"
+      "level": "Log level",
+      "invalidSubsystem": "Subsystem \"{subsystem}\" is not valid. Valid subsystems: {subsystems}",
+      "invalidLevel": "\"{level}\" is not a valid log level. Valid levels: debug, info, warn, error, dpanic, panic, fatal",
+      "invalidInput": "Input cannot be empty"
     },
     "warnings": {
       "potentialIssues": "Potential Issues:",

--- a/src/contexts/logs/api.ts
+++ b/src/contexts/logs/api.ts
@@ -24,6 +24,10 @@ interface RawLogEntry {
    * The message of the log
    */
   msg: string
+  /**
+   * Allow any additional structured fields
+   */
+  [key: string]: any
 }
 
 /**
@@ -119,11 +123,14 @@ export async function fetchLogSubsystems (ipfs: KuboRPCClient, signal?: AbortSig
  * Parse raw log entry into structured LogEntry
  */
 export function parseLogEntry (raw: unknown): LogEntry {
-  const obj = raw as RawLogEntry
+  const { ts, level, logger, caller, msg, ...attributes } = raw as RawLogEntry
+
   return {
-    timestamp: obj.ts,
-    level: obj.level,
-    subsystem: obj.logger,
-    message: obj.msg
+    timestamp: ts,
+    level,
+    subsystem: logger,
+    message: Object.keys(attributes).length > 0
+      ? `${msg} ${JSON.stringify(attributes)}`
+      : msg
   }
 }


### PR DESCRIPTION
This PR fixes a bug where details about event were skipped, and aligns log output in webui to match what `ipfs log tail` or `ipfs daemon` returns.

It was tested with kubo from:
- https://github.com/ipfs/kubo/pull/11039

which modernized go-log  and go-libp2p's slog shim:
- https://github.com/ipfs/go-log/pull/176
- https://github.com/libp2p/go-libp2p/pull/3424

## Before

> <img width="1007" height="912" alt="2025-11-05_17-53_1" src="https://github.com/user-attachments/assets/8820b306-2040-43fb-8c24-7a5c8944dcad" />

## After

> <img width="1009" height="1016" alt="2025-11-05_17-53" src="https://github.com/user-attachments/assets/e943ee1c-94d3-4da3-8fe6-c5cee9f14089" />

> <img width="1436" height="1044" alt="image" src="https://github.com/user-attachments/assets/3ba2231a-aa69-4a45-996e-db280b483a5a" />

> <img width="1413" height="185" alt="image" src="https://github.com/user-attachments/assets/652a1f59-e9f2-422c-922b-b46faa4ff986" />


ps. also addeed missing translation keys, e.g. it now correctly show:
> <img width="977" height="212" alt="2025-11-05_17-58" src="https://github.com/user-attachments/assets/1dfd2786-3499-4d6c-808b-0e4461cfbe56" />

