### PR TITLE
fix: CLI tutor commands missing some parameters

### DIFF
--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -230,8 +230,12 @@ class Modals extends React.Component {
         return cliCommandList[action](path)
       case cliCmdKeys.DOWNLOAD_OBJECT_COMMAND:
         return cliCommandList[action](activeCid)
+      case cliCmdKeys.DOWNLOAD_CAR_COMMAND:
+        return cliCommandList[action](activeCid)
       case cliCmdKeys.RENAME_IPFS_OBJECT:
         return cliCommandList[action](path, fileName)
+      case cliCmdKeys.PUBLISH_WITH_IPNS:
+        return cliCommandList[action](activeCid, 'self')
       case cliCmdKeys.PIN_OBJECT:
         return cliCommandList[action](activeCid, isPinned ? 'rm' : 'add')
       default:


### PR DESCRIPTION
The "Download CAR" command and the "Publish with IPNS" commands were missing some of the values that they needed to be complete. Adding those in.

The results look as the below screenshots for the two affected CLI tutor commands:

Download CAR:

<img width="1268" height="674" alt="Screenshot_2026-02-04_23-09-10" src="https://github.com/user-attachments/assets/c37f12c1-039c-4b41-ba86-bfa84fe6cff6" />

Pin to IPNS:

<img width="1280" height="684" alt="Screenshot_2026-02-04_23-08-56" src="https://github.com/user-attachments/assets/973d397f-1ba4-47a1-acc2-e69da2911dc7" />

See the previous views in the linked issue below.

There's also a "@TODO" item in this modified file:

```js
// @TODO: ensure path is set for all actions
```

If there are other commands to cover, maybe we can add them here too, and remove the TODO. Will check that in more detail, while waiting for feedback on the changes.

Closes #2469 