### PR TITLE
fix(peers): accept /p2p/ prefix in peer filter input

### DIFF
--- a/src/peers/PeersTable/PeersTable.js
+++ b/src/peers/PeersTable/PeersTable.js
@@ -156,6 +156,7 @@ export const PeersTable = ({ className, t, peerLocationsForSwarm, selectedPeers 
   const filteredPeerList = useMemo(() => {
     const filterLower = filter.toLowerCase()
     if (filterLower === '') return awaitedPeerLocationsForSwarm
+    const peerFilter = filter.startsWith('/p2p/') ? filter.slice(5) : filter
     return awaitedPeerLocationsForSwarm.filter(({ location, latency, peerId, connection, protocols, agentVersion }) => {
       if (location != null && location.toLowerCase().includes(filterLower)) {
         return true
@@ -163,7 +164,7 @@ export const PeersTable = ({ className, t, peerLocationsForSwarm, selectedPeers 
       if (latency != null && [latency, `${latency}ms`].some((str) => str.toString().includes(filterLower))) {
         return true
       }
-      if (peerId != null && peerId.toString().includes(filter)) {
+      if (peerId != null && peerId.toString().includes(peerFilter)) {
         return true
       }
       if (connection != null && connection.toLowerCase().includes(filterLower)) {


### PR DESCRIPTION
strip `/p2p/` prefix from filter before matching peer IDs, so pasting a value copied from the Peer ID column works directly.

- Closes #2468
- cc @imrehg if thats what you had in mind