### PR TITLE
feat: choose share link type, add native uris

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -46,13 +46,13 @@
     "placeholder": "Enter a URL (http://user:password@127.0.0.1:5001) or a Multiaddr (/ip4/127.0.0.1/tcp/5001)"
   },
   "publicGatewayForm": {
-    "placeholder": "Enter a URL (https://ipfs.io)"
+    "placeholder": "Enter an HTTP URL (https://path-gw.example.com)"
   },
   "localGatewayForm": {
-    "placeholder": "Enter a URL (http://localhost:8080)"
+    "placeholder": "Enter an HTTP URL (http://localhost:8080)"
   },
   "publicSubdomainGatewayForm": {
-    "placeholder": "Enter a URL (https://dweb.link)"
+    "placeholder": "Enter an HTTP URL (https://subdomain-gw.example.net)"
   },
   "ipfsCheckForm": {
     "label": "Retrieval Check Service URL",
@@ -90,7 +90,8 @@
     "pinStatus": "Pin Status",
     "publicKey": "Public key",
     "publicGateway": "Public Gateway",
-    "localGateway": "Local Gateway",
+    "publicSubdomainGateway": "Public Subdomain Gateway",
+    "localGateway": "Local HTTP Gateway",
     "rateIn": "Rate in",
     "rateOut": "Rate out",
     "repo": "Repo",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -28,7 +28,10 @@
   },
   "shareModal": {
     "title": "Share files",
-    "description": "Copy the link below and share it with your friends."
+    "description": "Copy the link below and share it with your friends.",
+    "descriptionLocal": "Use this link to open in apps running on this machine.",
+    "useLocalLink": "Local link for other apps on this machine",
+    "useSubdomains": "Use localhost subdomains for web apps"
   },
   "renameModal": {
     "titleFile": "Rename file",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -30,8 +30,9 @@
     "title": "Share files",
     "description": "Copy the link below and share it with your friends.",
     "descriptionLocal": "Use this link to open in apps running on this machine.",
-    "useLocalLink": "Local link for other apps on this machine",
-    "useSubdomains": "Use localhost subdomains for web apps"
+    "useLocalLink": "Local HTTP link for other apps on this machine",
+    "useSubdomains": "Use localhost subdomains for web apps",
+    "linkError": "Could not generate the link. Check that your IPFS node is running."
   },
   "renameModal": {
     "titleFile": "Rename file",

--- a/public/locales/en/files.json
+++ b/public/locales/en/files.json
@@ -7,6 +7,7 @@
   "individualFilesOnly": "Only available for individual files",
   "noPDFSupport": "Your browser does not support PDFs. Please download the PDF to view it:",
   "downloadPDF": "Download PDF",
+  "openWithLocalGateway": "Try opening it instead with your <1>local gateway</1>.",
   "openWithPublicGateway": "Try opening it instead with your <1>public gateway</1>.",
   "openWithLocalAndPublicGateway": "Try opening it instead with your <1>local gateway</1> or <3>public gateway</3>.",
   "cantBePreviewed": "Sorry, this file can’t be previewed",
@@ -30,6 +31,7 @@
     "title": "Share files",
     "description": "Copy the link below and share it with your friends.",
     "descriptionLocal": "Use this link to open in apps running on this machine.",
+    "descriptionNative": "This native IPFS address opens in apps and browsers that support IPFS, like the <1>IPFS Companion</1> extension.",
     "useLocalLink": "Local HTTP link for other apps on this machine",
     "useSubdomains": "Use localhost subdomains for web apps",
     "linkError": "Could not generate the link. Check that your IPFS node is running."

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -24,8 +24,39 @@
   },
   "apiDescription": "<0>If your node is configured with a <1>custom Kubo RPC API address</1>, including a port other than the default 5001, enter it here.</0>",
   "localGatewayDescription": "<0>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <1>gateway address</1> from your Kubo config.</0>",
-  "publicSubdomainGatewayDescription": "<0>Select a default <1>Subdomain Gateway</1> for generating shareable links.</0>",
-  "publicPathGatewayDescription": "<0>Select a fallback <1>Path Gateway</1> for generating shareable links for CIDs that exceed the 63-character DNS limit.</0>",
+  "shareLink": {
+    "title": "Sharing IPFS Links",
+    "intro": "This controls the link you copy with Share Link or Publish to IPNS. Native addresses are the default. The gateway options below copy a regular HTTP link instead, each for a specific need, so pick one only when you know you want it.",
+    "pathVsSubdomain": "Gateway links come in two shapes: <0>path</0> and <1>subdomain</1>. A path link puts everything from that gateway on one origin, the boundary your browser uses for cache, cookies, and saved logins, so one page can see what another left behind. A subdomain link gives each item its own origin, so your browser keeps them apart. Use a subdomain link for opening or hosting web pages, and a path link for non-browser apps.",
+    "recommendedBadge": "Recommended",
+    "gatewayGroupTitle": "HTTP gateway links",
+    "gatewayGroupNote": "These open in any HTTP client, but depend on a specific URL being reachable.",
+    "usesGateway": "Produces links like",
+    "subdomainNote": "Each item gets its own origin. Learn <0>how browsers keep sites apart</0>.",
+    "publicGatewayHelp": "New to public gateways? Find one with the <0>Public Gateway Checker</0>, or <1>run your own</1>.",
+    "publicGatewayEmptyHint": "To use this, enter a gateway address below.",
+    "native": {
+      "label": "Native (ipfs:// and ipns:// addresses)",
+      "description": "These addresses don't depend on any HTTP server, so they keep working even when a public gateway is down. Best for sharing with people peer-to-peer.",
+      "companionNote": "To open them, you and the people you share with can install the <0>IPFS Companion</0> browser extension. Everyone then loads content directly from each other, instead of depending on someone else's HTTP server."
+    },
+    "localPath": {
+      "label": "Local gateway, path link",
+      "description": "Opens content straight from your node on this computer. Good for local apps that aren't a browser. Does not work for sharing with other people."
+    },
+    "localSubdomain": {
+      "label": "Local gateway, subdomain link",
+      "description": "Like the option above, but for web apps on this computer that need origin isolation for security. Does not work for sharing with other people. Needs a gateway on localhost, not a raw IP."
+    },
+    "publicPath": {
+      "label": "Public gateway, path link",
+      "description": "A link anyone on the internet can open through a public gateway. Without origin isolation, don't use it for sensitive web apps."
+    },
+    "publicSubdomain": {
+      "label": "Public gateway, subdomain link",
+      "description": "Like the option above, but the safer choice for opening or hosting web pages and apps that require origin isolation."
+    }
+  },
   "retrievalDiagnosticService": {
     "title": "Retrieval Diagnostic Service",
     "description": "Configure the URL of the <0>ipfs-check</0> service used for <1>retrieval diagnostics</1>. This service checks if content can be successfully fetched from your node and other nodes hosting a specific CID, helping you troubleshoot sharing issues."

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -26,7 +26,7 @@
   "localGatewayDescription": "<0>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <1>gateway address</1> from your Kubo config.</0>",
   "shareLink": {
     "title": "Sharing IPFS Links",
-    "intro": "This controls the link you copy with Share Link or Publish to IPNS. Native addresses are the default. The gateway options below copy a regular HTTP link instead, each for a specific need, so pick one only when you know you want it.",
+    "intro": "This controls the link you copy with Share Link or Publish to IPNS. Each option fits a specific need, so pick the one that matches how the link will be opened.",
     "pathVsSubdomain": "Gateway links come in two shapes: <0>path</0> and <1>subdomain</1>. A path link puts everything from that gateway on one origin, the boundary your browser uses for cache, cookies, and saved logins, so one page can see what another left behind. A subdomain link gives each item its own origin, so your browser keeps them apart. Use a subdomain link for opening or hosting web pages, and a path link for non-browser apps.",
     "recommendedBadge": "Recommended",
     "gatewayGroupTitle": "HTTP gateway links",

--- a/public/locales/en/welcome.json
+++ b/public/locales/en/welcome.json
@@ -14,7 +14,7 @@
     "header": "What is IPFS?",
     "paragraph1": "<0><0>A hypermedia distribution protocol</0> that incorporates ideas from Kademlia, BitTorrent, Git, and more</0>",
     "paragraph2": "<0><0>A peer-to-peer file transfer network</0> with a completely decentralized architecture and no central point of failure, censorship, or control</0>",
-    "paragraph3": "<0><0>An on-ramp to tomorrow's web</0> — traditional browsers can access IPFS files through gateways like <2>https://dweb.link</2> or directly using the <4>IPFS Companion</4> extension</0>",
+    "paragraph3": "<0><0>An on-ramp to tomorrow's web</0>: traditional browsers can access IPFS content through an HTTP gateway, or directly with the <2>IPFS Companion</2> extension</0>",
     "paragraph4": "<0><0>A next-gen CDN</0> — just add a file to your node to make it available to the world with cache-friendly content-hash addressing and BitTorrent-style bandwidth distribution</0>",
     "paragraph5": "<0><0>A developer toolset</0> for building <2>completely distributed apps and services</2>, backed by a robust open-source community</0>"
   },

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -1,9 +1,6 @@
-import memoize from 'p-memoize'
 import { multiaddrToUri as toUri } from '@multiformats/multiaddr-to-uri'
 import { createAsyncResourceBundle, createSelector } from 'redux-bundler'
 import { contextBridge } from '../helpers/context-bridge'
-
-const LOCAL_HOSTNAMES = ['127.0.0.1', '[::1]', '0.0.0.0', '[::]']
 
 const bundle = createAsyncResourceBundle({
   name: 'config',
@@ -23,36 +20,15 @@ const bundle = createAsyncResourceBundle({
 
     const config = JSON.parse(conf)
 
-    // An explicit Local Gateway URL is the gateway the browser is meant to reach
-    // for everything (reverse proxy, Docker, non-default host or port), so trust
-    // it for the reachability-probed availableGateway too. Without this, the
-    // 127.0.0.1 probe below fails for remote users and previews, thumbnails and
-    // IPNS links fall back to the public gateway instead of the user's own node.
+    // availableGateway drives previews, thumbnails, IPNS links and the Explore
+    // link: the user's Local Gateway URL override, or the gateway from the Kubo
+    // config, chosen without any reachability probing. selectAvailableGatewayUrl
+    // only falls back to a public gateway (through selectGatewayUrl) when no
+    // local gateway is configured at all.
     // https://github.com/ipfs/ipfs-webui/issues/2458
-    const localGateway = store.selectLocalGateway()
-    if (localGateway) {
-      store.doSetAvailableGateway(localGateway)
-      return conf
-    }
-
-    const publicGateway = store.selectPublicGateway()
-    const url = getURLFromAddress('Gateway', config) || publicGateway
-
-    // Normalize local hostnames to localhost
-    // to leverage subdomain gateway, if present
-    // https://github.com/ipfs-shipyard/ipfs-webui/issues/1490
-    const gw = new URL(url)
-    if (LOCAL_HOSTNAMES.includes(gw.hostname)) {
-      gw.hostname = 'localhost'
-      const localUrl = gw.toString().replace(/\/+$/, '') // no trailing slashes
-      if (await checkIfSubdomainGatewayUrlIsAccessible(localUrl)) {
-        store.doSetAvailableGateway(localUrl)
-        return conf
-      }
-    }
-
-    if (!await checkIfGatewayUrlIsAccessible(url)) {
-      store.doSetAvailableGateway(publicGateway)
+    const gateway = store.selectLocalGateway() || getURLFromAddress('Gateway', config)
+    if (gateway) {
+      store.doSetAvailableGateway(gateway)
     }
 
     // stringy json for quick compares
@@ -126,32 +102,5 @@ function getURLFromAddress (name, config) {
     return null
   }
 }
-
-const checkIfGatewayUrlIsAccessible = memoize(async (url) => {
-  try {
-    const { status } = await fetch(
-    `${url}/ipfs/bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss`
-    )
-    return status === 200
-  } catch (e) {
-    console.error(`Unable to use the gateway at ${url}. The public gateway will be used as a fallback`, e)
-    return false
-  }
-})
-
-// Separate test is necessary to see if subdomain mode is possible,
-// because some browser+OS combinations won't resolve them:
-// https://github.com/ipfs/kubo/issues/7527
-const checkIfSubdomainGatewayUrlIsAccessible = memoize(async (url) => {
-  try {
-    url = new URL(url)
-    url.hostname = `bafkqae2xmvwgg33nmuqhi3zajfiemuzahiwss.ipfs.${url.hostname}`
-    const { status } = await fetch(url.toString())
-    return status === 200
-  } catch (e) {
-    console.error(`Unable to use the subdomain gateway at ${url}. Regular gateway will be used as a fallback`, e)
-    return false
-  }
-})
 
 export default bundle

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -51,16 +51,24 @@ bundle.reactIsSameOriginToBridge = createSelector(
   }
 )
 
-bundle.selectGatewayUrl = createSelector(
+bundle.selectLocalGatewayUrl = createSelector(
   'selectConfigObject',
-  'selectPublicGateway',
   'selectLocalGateway',
-  (config, publicGateway, localGateway) => {
-    // Priority: 1) User-configured local gateway, 2) Kubo config, 3) Public gateway
-    const url = localGateway || getURLFromAddress('Gateway', config) || publicGateway
+  (config, localGateway) => {
+    // Priority: 1) User-configured local gateway, 2) Kubo config. Never the
+    // public gateway: consumers use this where "local" is a promise (share
+    // links and content links labeled as same-machine).
+    const url = localGateway || getURLFromAddress('Gateway', config) || ''
     // Normalize: remove trailing slashes to avoid double slashes when constructing paths
     return url.replace(/\/+$/, '')
   }
+)
+
+bundle.selectGatewayUrl = createSelector(
+  'selectLocalGatewayUrl',
+  'selectPublicGateway',
+  (localGatewayUrl, publicGateway) =>
+    localGatewayUrl || publicGateway.replace(/\/+$/, '')
 )
 
 bundle.selectAvailableGatewayUrl = createSelector(

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -600,12 +600,26 @@ const actions = () => ({
     // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
     const publicGateway = store.selectPublicGateway()
     const publicSubdomainGateway = store.selectPublicSubdomainGateway()
+    const gatewayUrl = store.selectGatewayUrl()
     const { link: shareableLink, cid } = await getShareableLink(files, publicGateway, publicSubdomainGateway, ipfs)
+
+    // Build local gateway link for use in external apps
+    let filename = ''
+    if (files.length === 1 && files[0].type === 'file') {
+      filename = `?filename=${encodeURIComponent(files[0].name)}`
+    }
+    const localLink = `${gatewayUrl}/ipfs/${cid}${filename}`
+
+    // Build localhost subdomain link for web apps (origin isolation)
+    const gwUrl = new URL(gatewayUrl)
+    const base32Cid = cid.toV1().toString()
+    const port = gwUrl.port ? `:${gwUrl.port}` : ''
+    const subdomainLocalLink = `http://${base32Cid}.ipfs.localhost${port}/${filename}`
 
     // Trigger background provide operation with the CID from getShareableLink
     dispatchAsyncProvide(cid, ipfs)
 
-    return shareableLink
+    return { link: shareableLink, localLink, subdomainLocalLink }
   }),
 
   /**

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -1,7 +1,7 @@
 /* eslint-disable require-yield */
 
 import { join, dirname, basename } from 'path'
-import { getDownloadLink, getShareableLink, getCarLink } from '../../lib/files.js'
+import { getDownloadLink, getShareableLink, getCarLink, getLocalLinks } from '../../lib/files.js'
 import countDirs from '../../lib/count-dirs.js'
 import memoize from 'p-memoize'
 import all from 'it-all'
@@ -603,18 +603,9 @@ const actions = () => ({
     const gatewayUrl = store.selectGatewayUrl()
     const { link: shareableLink, cid } = await getShareableLink(files, publicGateway, publicSubdomainGateway, ipfs)
 
-    // Build local gateway link for use in external apps
-    let filename = ''
-    if (files.length === 1 && files[0].type === 'file') {
-      filename = `?filename=${encodeURIComponent(files[0].name)}`
-    }
-    const localLink = `${gatewayUrl}/ipfs/${cid}${filename}`
-
-    // Build localhost subdomain link for web apps (origin isolation)
-    const gwUrl = new URL(gatewayUrl)
-    const base32Cid = cid.toV1().toString()
-    const port = gwUrl.port ? `:${gwUrl.port}` : ''
-    const subdomainLocalLink = `http://${base32Cid}.ipfs.localhost${port}/${filename}`
+    // Local gateway links for opening content in other apps on this machine.
+    // selectGatewayUrl honors the user's Local Gateway URL override.
+    const { localLink, subdomainLocalLink } = getLocalLinks(files, cid, gatewayUrl)
 
     // Trigger background provide operation with the CID from getShareableLink
     dispatchAsyncProvide(cid, ipfs)

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -1,7 +1,8 @@
 /* eslint-disable require-yield */
 
 import { join, dirname, basename } from 'path'
-import { getDownloadLink, getShareableLink, getCarLink, getLocalLinks } from '../../lib/files.js'
+import { getDownloadLink, getCarLink, resolveShareCid } from '../../lib/files.js'
+import { SHARE_LINK_TYPE, buildShareLink, getFilenameQuery, getLocalLinks } from '../../lib/share-link.js'
 import countDirs from '../../lib/count-dirs.js'
 import memoize from 'p-memoize'
 import all from 'it-all'
@@ -155,6 +156,7 @@ const getPinCIDs = (ipfs) => map(getRawPins(ipfs), (pin) => pin.cid)
  * @property {function():string} selectGatewayUrl
  * @property {function():string} selectPublicGateway
  * @property {function():string} selectPublicSubdomainGateway
+ * @property {function():string} selectEffectiveShareLinkType
  *
  * @typedef {Object} UnkonwActions
  * @property {function(string):Promise<unknown>} doUpdateHash
@@ -598,19 +600,38 @@ const actions = () => ({
 
   doFilesShareLink: (/** @type {FileStat[]} */ files) => perform(ACTIONS.SHARE_LINK, async (ipfs, { store }) => {
     // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
+    const cid = await resolveShareCid(files, ipfs)
+    const filename = getFilenameQuery(files)
+    const gatewayUrl = store.selectGatewayUrl()
     const publicGateway = store.selectPublicGateway()
     const publicSubdomainGateway = store.selectPublicSubdomainGateway()
-    const gatewayUrl = store.selectGatewayUrl()
-    const { link: shareableLink, cid } = await getShareableLink(files, publicGateway, publicSubdomainGateway, ipfs)
 
-    // Local gateway links for opening content in other apps on this machine.
-    // selectGatewayUrl honors the user's Local Gateway URL override.
-    const { localLink, subdomainLocalLink } = getLocalLinks(files, cid, gatewayUrl)
+    const linkOpts = {
+      namespace: 'ipfs',
+      pathId: cid.toString(),
+      subdomainLabel: cid.toV1().toString(),
+      filename,
+      localGatewayUrl: gatewayUrl,
+      publicGateway,
+      publicSubdomainGateway
+    }
 
-    // Trigger background provide operation with the CID from getShareableLink
+    // The chosen link type drives what we copy. An unbuildable choice (e.g. a
+    // public type whose gateway was cleared) falls back to a native ipfs:// URI.
+    let type = store.selectEffectiveShareLinkType()
+    let link = buildShareLink({ type, ...linkOpts })
+    if (!link) {
+      type = SHARE_LINK_TYPE.NATIVE
+      link = buildShareLink({ type, ...linkOpts })
+    }
+
+    // Local variants for the in-modal override, offered when the chosen type is
+    // native or public so users can still grab a same-machine link.
+    const { localLink, subdomainLocalLink } = getLocalLinks(cid, filename, gatewayUrl)
+
     dispatchAsyncProvide(cid, ipfs)
 
-    return { link: shareableLink, localLink, subdomainLocalLink }
+    return { link, type, localLink, subdomainLocalLink }
   }),
 
   /**

--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -2,7 +2,7 @@
 
 import { join, dirname, basename } from 'path'
 import { getDownloadLink, getCarLink, resolveShareCid } from '../../lib/files.js'
-import { SHARE_LINK_TYPE, buildShareLink, getFilenameQuery, getLocalLinks } from '../../lib/share-link.js'
+import { buildShareLink, getFilenameQuery, getLocalLinks } from '../../lib/share-link.js'
 import countDirs from '../../lib/count-dirs.js'
 import memoize from 'p-memoize'
 import all from 'it-all'
@@ -154,6 +154,7 @@ const getPinCIDs = (ipfs) => map(getRawPins(ipfs), (pin) => pin.cid)
  * @typedef {Object} ConfigSelectors
  * @property {function():string} selectApiUrl
  * @property {function():string} selectGatewayUrl
+ * @property {function():string} selectLocalGatewayUrl
  * @property {function():string} selectPublicGateway
  * @property {function():string} selectPublicSubdomainGateway
  * @property {function():string} selectEffectiveShareLinkType
@@ -602,32 +603,29 @@ const actions = () => ({
     // ensureMFS deliberately omitted here, see https://github.com/ipfs/ipfs-webui/issues/1744 for context.
     const cid = await resolveShareCid(files, ipfs)
     const filename = getFilenameQuery(files)
-    const gatewayUrl = store.selectGatewayUrl()
+    // Local-only gateway (user override or Kubo config): a link labeled local
+    // must never point at the public gateway.
+    const localGatewayUrl = store.selectLocalGatewayUrl()
     const publicGateway = store.selectPublicGateway()
     const publicSubdomainGateway = store.selectPublicSubdomainGateway()
 
-    const linkOpts = {
+    // The effective type already falls back to native when the chosen type's
+    // gateway is not configured, so buildShareLink always returns a link here.
+    const type = store.selectEffectiveShareLinkType()
+    const link = buildShareLink({
+      type,
       namespace: 'ipfs',
       pathId: cid.toString(),
       subdomainLabel: cid.toV1().toString(),
       filename,
-      localGatewayUrl: gatewayUrl,
+      localGatewayUrl,
       publicGateway,
       publicSubdomainGateway
-    }
-
-    // The chosen link type drives what we copy. An unbuildable choice (e.g. a
-    // public type whose gateway was cleared) falls back to a native ipfs:// URI.
-    let type = store.selectEffectiveShareLinkType()
-    let link = buildShareLink({ type, ...linkOpts })
-    if (!link) {
-      type = SHARE_LINK_TYPE.NATIVE
-      link = buildShareLink({ type, ...linkOpts })
-    }
+    })
 
     // Local variants for the in-modal override, offered when the chosen type is
     // native or public so users can still grab a same-machine link.
-    const { localLink, subdomainLocalLink } = getLocalLinks(cid, filename, gatewayUrl)
+    const { localLink, subdomainLocalLink } = getLocalLinks(cid, filename, localGatewayUrl)
 
     dispatchAsyncProvide(cid, ipfs)
 

--- a/src/bundles/files/protocol.ts
+++ b/src/bundles/files/protocol.ts
@@ -78,6 +78,12 @@ export type FileDownload = {
   filename: string
 }
 export type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
+export type ShareLinks = {
+  link: string
+  localLink: string
+  subdomainLocalLink: string
+}
+export type ShareLink = Perform<'FILES_SHARE_LINK', Error, ShareLinks, void>
 
 export type Message =
   | { type: 'FILES_CLEAR_ALL' }
@@ -91,7 +97,7 @@ export type Message =
   | AddByPath
   | BulkCidImport
   | DownloadLink
-  | Perform<'FILES_SHARE_LINK', Error, string, void>
+  | ShareLink
   | Perform<'FILES_COPY', Error, void, void>
   | Perform<'FILES_PIN_ADD', Error, Pin[], void>
   | Perform<'FILES_PIN_REMOVE', Error, Pin[], void>

--- a/src/bundles/files/protocol.ts
+++ b/src/bundles/files/protocol.ts
@@ -80,6 +80,7 @@ export type FileDownload = {
 export type DownloadLink = Perform<'FILES_DOWNLOADLINK', Error, FileDownload, void>
 export type ShareLinks = {
   link: string
+  type: string
   localLink: string
   subdomainLocalLink: string
 }

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -1,22 +1,17 @@
+import { createSelector } from 'redux-bundler'
 import { readSetting, writeSetting } from './local-storage.js'
+import { SHARE_LINK_TYPE, DEFAULT_SHARE_LINK_TYPE, resolveEffectiveShareLinkType } from '../lib/share-link.js'
 
-// TODO: switch to dweb.link when https://github.com/ipfs/kubo/issues/7318
-export const DEFAULT_PATH_GATEWAY = 'https://ipfs.io'
-export const DEFAULT_SUBDOMAIN_GATEWAY = 'https://dweb.link'
 export const DEFAULT_IPFS_CHECK_URL = 'https://check.ipfs.network'
-// Test URLs that bypass validation for e2e tests
+// Test gateway URLs used by e2e tests
 export const TEST_PATH_GATEWAY = 'https://e2e-test-path-gateway.test'
 export const TEST_SUBDOMAIN_GATEWAY = 'https://e2e-test-subdomain-gateway.test'
-const IMG_HASH_1PX = 'bafkreib6wedzfupqy7qh44sie42ub4mvfwnfukmw6s2564flajwnt4cvc4' // 1x1.png
-const IMG_ARRAY = [
-  { id: 'IMG_HASH_1PX', name: '1x1.png', hash: IMG_HASH_1PX },
-  { id: 'IMG_HASH_1PXID', name: '1x1.png', hash: 'bafkqax4jkbheodikdifaaaaabveuqrcsaaaaaaiaaaaacaidaaaaajo3k3faaaaaanieyvcfaaaabj32hxnaaaaaaf2fetstabaonwdgaaaaacsjiravicgxmnqaaaaaaiaadyrbxqzqaaaaabeuktsevzbgbaq' },
-  { id: 'IMG_HASH_FAVICON', name: 'favicon.ico', hash: 'bafkreihc7efnl2prri6j6krcopelxms3xsh7undpsjqbfsasm7ikiyha4i' }
-]
 
+// Public gateways start empty until the user opts in, so a fresh node shares
+// native ipfs:// links rather than routing through a third-party gateway.
 const readPublicGatewaySetting = () => {
   const setting = readSetting('ipfsPublicGateway')
-  return setting || DEFAULT_PATH_GATEWAY
+  return typeof setting === 'string' ? setting : ''
 }
 
 const readLocalGatewaySetting = () => {
@@ -28,7 +23,7 @@ const readLocalGatewaySetting = () => {
 
 const readPublicSubdomainGatewaySetting = () => {
   const setting = readSetting('ipfsPublicSubdomainGateway')
-  return setting || DEFAULT_SUBDOMAIN_GATEWAY
+  return typeof setting === 'string' ? setting : ''
 }
 
 const readIpfsCheckUrlSetting = () => {
@@ -36,12 +31,24 @@ const readIpfsCheckUrlSetting = () => {
   return setting || DEFAULT_IPFS_CHECK_URL
 }
 
+const readShareLinkTypeSetting = () => {
+  const setting = readSetting('ipfsShareLinkType')
+  return typeof setting === 'string' && Object.values(SHARE_LINK_TYPE).includes(setting)
+    ? setting
+    : DEFAULT_SHARE_LINK_TYPE
+}
+
 const init = () => ({
   availableGateway: null,
   publicGateway: readPublicGatewaySetting(),
   publicSubdomainGateway: readPublicSubdomainGatewaySetting(),
   ipfsCheckUrl: readIpfsCheckUrlSetting(),
-  localGateway: readLocalGatewaySetting()
+  localGateway: readLocalGatewaySetting(),
+  shareLinkType: readShareLinkTypeSetting(),
+  // Not persisted: set when the local gateway changes so the Explore page
+  // reloads its Helia node (which reads kuboGateway only at startup) the next
+  // time it is opened. A page reload resets this back to false.
+  explorerNeedsReload: false
 })
 
 /**
@@ -84,139 +91,6 @@ export const localGatewayToKuboGateway = (gatewayUrl) => {
   }
 }
 
-/**
- * Check if any hashes from IMG_ARRAY can be loaded from the provided gatewayUrl
- * @param {string} gatewayUrl - The gateway URL to check
- * @see https://github.com/ipfs/ipfs-webui/issues/1937#issuecomment-1152894211 for more info
- */
-export const checkViaImgSrc = (gatewayUrl) => {
-  // Skip validation for test gateways
-  if (gatewayUrl === TEST_PATH_GATEWAY) {
-    return Promise.resolve()
-  }
-
-  const url = new URL(gatewayUrl)
-
-  /**
-   * we check if gateway is up by loading 1x1 px image:
-   * this is more robust check than loading js, as it won't be blocked
-   * by privacy protections present in modern browsers or in extensions such as Privacy Badger
-   */
-  // @ts-expect-error - Promise.any requires ES2021 but we're on ES2020
-  return Promise.any(IMG_ARRAY.map(element => {
-    // url.host (not hostname) keeps the port, so the probe also works for local
-    // gateways on non-default ports, e.g. http://127.0.0.1:8080.
-    const imgUrl = new URL(`${url.protocol}//${url.host}/ipfs/${element.hash}?now=${Date.now()}&filename=${element.name}#x-ipfs-companion-no-redirect`)
-    return checkImgSrcPromise(imgUrl)
-  }))
-}
-
-/**
- * @param {URL} imgUrl - The image URL to check
- * @returns {Promise<void>}
- */
-const checkImgSrcPromise = (imgUrl) => {
-  const imgCheckTimeout = 15000
-
-  return new Promise((resolve, reject) => {
-    const timeout = () => {
-      if (!timer) return false
-      clearTimeout(timer)
-      timer = null
-      return true
-    }
-
-    /** @type {NodeJS.Timeout | null} */
-    let timer = setTimeout(() => { if (timeout()) reject(new Error(`Image load timed out after ${imgCheckTimeout / 1000} seconds for URL: ${imgUrl}`)) }, imgCheckTimeout)
-    const img = new Image()
-
-    img.onerror = () => {
-      timeout()
-      reject(new Error(`Failed to load image from URL: ${imgUrl}`))
-    }
-
-    img.onload = () => {
-      // subdomain works
-      timeout()
-      resolve()
-    }
-
-    img.src = imgUrl.toString()
-  })
-}
-
-/**
- * Checks if a given URL redirects to a subdomain that starts with a specific hash.
- *
- * @param {URL} url - The URL to check for redirection.
- * @throws {Error} Throws an error if the URL does not redirect to the expected subdomain.
- * @returns {Promise<void>} A promise that resolves if the URL redirects correctly, otherwise it throws an error.
- */
-async function expectSubdomainRedirect (url) {
-  // Detecting redirects on remote Origins is extra tricky,
-  // but we seem to be able to access xhr.responseURL which is enough to see
-  // if paths are redirected to subdomains.
-
-  const { url: responseUrl } = await fetch(url.toString())
-  const { hostname } = new URL(responseUrl)
-
-  if (!hostname.startsWith(IMG_HASH_1PX)) {
-    const msg = `Expected ${url.toString()} to redirect to subdomain '${IMG_HASH_1PX}' but instead received '${responseUrl}'`
-    console.error(msg)
-    throw new Error(msg)
-  }
-}
-
-/**
- * Checks if an image can be loaded from a given URL within a specified timeout.
- *
- * @param {URL} imgUrl - The URL of the image to be loaded.
- * @returns {Promise<void>} A promise that resolves if the image loads successfully within the timeout, otherwise it rejects with an error.
- */
-async function checkViaImgUrl (imgUrl) {
-  try {
-    await checkImgSrcPromise(imgUrl)
-  } catch (error) {
-    throw new Error(`Error or timeout when attempting to load img from '${imgUrl.toString()}'`)
-  }
-}
-
-/**
- * Checks if a given gateway URL is functioning correctly by verifying image loading and redirection.
- *
- * @param {string} gatewayUrl - The URL of the gateway to be checked.
- * @returns {Promise<boolean>} A promise that resolves to true if the gateway is functioning correctly, otherwise false.
- */
-export async function checkSubdomainGateway (gatewayUrl) {
-  if (gatewayUrl === DEFAULT_SUBDOMAIN_GATEWAY || gatewayUrl === TEST_SUBDOMAIN_GATEWAY) {
-    // avoid sending probe requests to the default gateway every time Settings page is opened
-    // also skip validation for test gateways
-    return true
-  }
-  /** @type {URL} */
-  let imgSubdomainUrl
-  /** @type {URL} */
-  let imgRedirectedPathUrl
-  try {
-    const gwUrl = new URL(gatewayUrl)
-    imgSubdomainUrl = new URL(`${gwUrl.protocol}//${IMG_HASH_1PX}.ipfs.${gwUrl.hostname}/?now=${Date.now()}&filename=1x1.png#x-ipfs-companion-no-redirect`)
-    imgRedirectedPathUrl = new URL(`${gwUrl.protocol}//${gwUrl.hostname}/ipfs/${IMG_HASH_1PX}?now=${Date.now()}&filename=1x1.png#x-ipfs-companion-no-redirect`)
-  } catch (err) {
-    console.error('Invalid URL:', err)
-    return false
-  }
-  return await checkViaImgUrl(imgSubdomainUrl)
-    .then(async () => expectSubdomainRedirect(imgRedirectedPathUrl))
-    .then(() => {
-      console.log(`Gateway at '${gatewayUrl}' is functioning correctly (verified image loading and redirection)`)
-      return true
-    })
-    .catch((err) => {
-      console.error(err)
-      return false
-    })
-}
-
 const bundle = {
   name: 'gateway',
 
@@ -246,6 +120,14 @@ const bundle = {
       return { ...state, localGateway: action.payload }
     }
 
+    if (action.type === 'SET_SHARE_LINK_TYPE') {
+      return { ...state, shareLinkType: action.payload }
+    }
+
+    if (action.type === 'SET_EXPLORER_NEEDS_RELOAD') {
+      return { ...state, explorerNeedsReload: action.payload }
+    }
+
     return state
   },
 
@@ -257,20 +139,28 @@ const bundle = {
 
   /**
    * @param {string} address
-   * @returns {function({dispatch: Function}): Promise<void>}
+   * @returns {function({dispatch: Function, store: any}): Promise<void>}
    */
-  doUpdatePublicGateway: (address) => async ({ dispatch }) => {
+  doUpdatePublicGateway: (address) => async ({ dispatch, store }) => {
     await writeSetting('ipfsPublicGateway', address)
     dispatch({ type: 'SET_PUBLIC_GATEWAY', payload: address })
+    // Clearing the gateway that the Share Link type points at reverts the choice
+    // to native, so the selected option matches what is actually configured.
+    if (!address && store.selectShareLinkType() === SHARE_LINK_TYPE.PUBLIC_PATH) {
+      await store.doUpdateShareLinkType(SHARE_LINK_TYPE.NATIVE)
+    }
   },
 
   /**
    * @param {string} address
-   * @returns {function({dispatch: Function}): Promise<void>}
+   * @returns {function({dispatch: Function, store: any}): Promise<void>}
    */
-  doUpdatePublicSubdomainGateway: (address) => async ({ dispatch }) => {
+  doUpdatePublicSubdomainGateway: (address) => async ({ dispatch, store }) => {
     await writeSetting('ipfsPublicSubdomainGateway', address)
     dispatch({ type: 'SET_PUBLIC_SUBDOMAIN_GATEWAY', payload: address })
+    if (!address && store.selectShareLinkType() === SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN) {
+      await store.doUpdateShareLinkType(SHARE_LINK_TYPE.NATIVE)
+    }
   },
 
   /**
@@ -284,13 +174,19 @@ const bundle = {
 
   /**
    * @param {string} address
-   * @returns {function({dispatch: Function}): Promise<void>}
+   * @returns {function({dispatch: Function, store: any}): Promise<void>}
    */
-  doUpdateLocalGateway: (address) => async ({ dispatch }) => {
+  doUpdateLocalGateway: (address) => async ({ dispatch, store }) => {
     // Normalize: remove trailing slashes
     const normalizedAddress = address.replace(/\/+$/, '')
     await writeSetting('ipfsLocalGateway', normalizedAddress)
     dispatch({ type: 'SET_LOCAL_GATEWAY', payload: normalizedAddress })
+
+    // Refresh availableGateway now (the override when set, the Kubo config
+    // gateway when cleared) so previews, thumbnails, IPNS links and the Explore
+    // link switch immediately, instead of waiting for the config bundle to go
+    // stale.
+    store.doSetAvailableGateway(store.selectGatewayUrl())
 
     // Keep kuboGateway (used by Helia/Explore) in sync with the override.
     if (normalizedAddress) {
@@ -303,6 +199,11 @@ const bundle = {
       // Override cleared: restore defaults so Explore stops using the old host.
       await writeSetting('kuboGateway', DEFAULT_KUBO_GATEWAY)
     }
+
+    // The Explore page's Helia node reads kuboGateway only when it boots, so it
+    // cannot pick up the change in place. Flag it to reload the next time the
+    // user opens Explore; that reload clears this (non-persisted) flag.
+    dispatch({ type: 'SET_EXPLORER_NEEDS_RELOAD', payload: true })
   },
 
   /**
@@ -333,7 +234,42 @@ const bundle = {
    * @param {any} state
    * @returns {string}
    */
-  selectLocalGateway: (state) => state?.gateway?.localGateway
+  selectLocalGateway: (state) => state?.gateway?.localGateway,
+
+  /**
+   * Whether the Explore page should reload to re-init its Helia node after a
+   * local gateway change. See ExploreContainer.
+   * @param {any} state
+   * @returns {boolean}
+   */
+  selectExplorerNeedsReload: (state) => state?.gateway?.explorerNeedsReload,
+
+  /**
+   * @param {string} type - a SHARE_LINK_TYPE value
+   * @returns {function({dispatch: Function}): Promise<void>}
+   */
+  doUpdateShareLinkType: (type) => async ({ dispatch }) => {
+    await writeSetting('ipfsShareLinkType', type)
+    dispatch({ type: 'SET_SHARE_LINK_TYPE', payload: type })
+  },
+
+  /**
+   * The link type the user selected for Share Link and Publish to IPNS.
+   * @param {any} state
+   * @returns {string}
+   */
+  selectShareLinkType: (state) => state?.gateway?.shareLinkType,
+
+  // The link type actually used: a public type falls back to native when its
+  // public gateway is empty, so the two consumers (Share Link, Publish to IPNS)
+  // stay consistent with the disabled-option logic in Settings.
+  selectEffectiveShareLinkType: createSelector(
+    'selectShareLinkType',
+    'selectPublicGateway',
+    'selectPublicSubdomainGateway',
+    (shareLinkType, publicGateway, publicSubdomainGateway) =>
+      resolveEffectiveShareLinkType(shareLinkType, { publicGateway, publicSubdomainGateway })
+  )
 }
 
 export default bundle

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -2,16 +2,23 @@ import { createSelector } from 'redux-bundler'
 import { readSetting, writeSetting } from './local-storage.js'
 import { SHARE_LINK_TYPE, DEFAULT_SHARE_LINK_TYPE, resolveEffectiveShareLinkType } from '../lib/share-link.js'
 
+// Public gateways prefilled on a fresh node; DEFAULT_SHARE_LINK_TYPE in
+// lib/share-link.js points share links at the subdomain one. Clearing a
+// gateway in Settings opts out of it entirely (share links then fall back to
+// native ipfs:// URIs). Set these to '' to ship with no predefined public
+// gateways at all.
+export const DEFAULT_PATH_GATEWAY = 'https://ipfs.io'
+export const DEFAULT_SUBDOMAIN_GATEWAY = 'https://dweb.link'
 export const DEFAULT_IPFS_CHECK_URL = 'https://check.ipfs.network'
 // Test gateway URLs used by e2e tests
 export const TEST_PATH_GATEWAY = 'https://e2e-test-path-gateway.test'
 export const TEST_SUBDOMAIN_GATEWAY = 'https://e2e-test-subdomain-gateway.test'
 
-// Public gateways start empty until the user opts in, so a fresh node shares
-// native ipfs:// links rather than routing through a third-party gateway.
+// A stored '' means the user cleared the gateway to opt out of public gateway
+// links; only a setting that was never written gets the default.
 const readPublicGatewaySetting = () => {
   const setting = readSetting('ipfsPublicGateway')
-  return typeof setting === 'string' ? setting : ''
+  return typeof setting === 'string' ? setting : DEFAULT_PATH_GATEWAY
 }
 
 const readLocalGatewaySetting = () => {
@@ -23,7 +30,7 @@ const readLocalGatewaySetting = () => {
 
 const readPublicSubdomainGatewaySetting = () => {
   const setting = readSetting('ipfsPublicSubdomainGateway')
-  return typeof setting === 'string' ? setting : ''
+  return typeof setting === 'string' ? setting : DEFAULT_SUBDOMAIN_GATEWAY
 }
 
 const readIpfsCheckUrlSetting = () => {
@@ -249,11 +256,20 @@ const bundle = {
 
   /**
    * @param {string} type - a SHARE_LINK_TYPE value
-   * @returns {function({dispatch: Function}): Promise<void>}
+   * @returns {function({dispatch: Function, store: any}): Promise<void>}
    */
-  doUpdateShareLinkType: (type) => async ({ dispatch }) => {
+  doUpdateShareLinkType: (type) => async ({ dispatch, store }) => {
     await writeSetting('ipfsShareLinkType', type)
     dispatch({ type: 'SET_SHARE_LINK_TYPE', payload: type })
+    // Choosing a public type also persists the gateway it points at: a
+    // prefilled default is otherwise never written (the gateway form's Submit
+    // is disabled while the value is unchanged), and an explicit opt-in must
+    // keep its gateway even if the DEFAULT_*_GATEWAY constants change later.
+    if (type === SHARE_LINK_TYPE.PUBLIC_PATH) {
+      await writeSetting('ipfsPublicGateway', store.selectPublicGateway())
+    } else if (type === SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN) {
+      await writeSetting('ipfsPublicSubdomainGateway', store.selectPublicSubdomainGateway())
+    }
   },
 
   /**

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -179,6 +179,9 @@ const bundle = {
   doUpdateLocalGateway: (address) => async ({ dispatch, store }) => {
     // Normalize: remove trailing slashes
     const normalizedAddress = address.replace(/\/+$/, '')
+    // Re-saving the same value must not rewrite settings or schedule a
+    // spurious Explore reload.
+    if (normalizedAddress === store.selectLocalGateway()) return
     await writeSetting('ipfsLocalGateway', normalizedAddress)
     dispatch({ type: 'SET_LOCAL_GATEWAY', payload: normalizedAddress })
 
@@ -260,15 +263,18 @@ const bundle = {
    */
   selectShareLinkType: (state) => state?.gateway?.shareLinkType,
 
-  // The link type actually used: a public type falls back to native when its
-  // public gateway is empty, so the two consumers (Share Link, Publish to IPNS)
-  // stay consistent with the disabled-option logic in Settings.
+  // The link type actually used: a type whose gateway is not configured (a
+  // public type with its gateway cleared, or a local type with no local
+  // gateway) falls back to native, so the two consumers (Share Link, Publish
+  // to IPNS) stay consistent with the disabled-option logic in Settings and
+  // buildShareLink always produces a link for this type.
   selectEffectiveShareLinkType: createSelector(
     'selectShareLinkType',
     'selectPublicGateway',
     'selectPublicSubdomainGateway',
-    (shareLinkType, publicGateway, publicSubdomainGateway) =>
-      resolveEffectiveShareLinkType(shareLinkType, { publicGateway, publicSubdomainGateway })
+    'selectLocalGatewayUrl',
+    (shareLinkType, publicGateway, publicSubdomainGateway, localGatewayUrl) =>
+      resolveEffectiveShareLinkType(shareLinkType, { publicGateway, publicSubdomainGateway, localGatewayUrl })
   )
 }
 

--- a/src/bundles/gateway.test.js
+++ b/src/bundles/gateway.test.js
@@ -1,5 +1,9 @@
-/* global describe, it, expect */
-import { localGatewayToKuboGateway, checkValidHttpUrl } from './gateway.js'
+/* global describe, it, expect, beforeEach */
+import { composeBundles } from 'redux-bundler'
+import gatewayBundle, { localGatewayToKuboGateway, checkValidHttpUrl, DEFAULT_KUBO_GATEWAY } from './gateway.js'
+import configBundle from './config.js'
+import { readSetting } from './local-storage.js'
+import { SHARE_LINK_TYPE, DEFAULT_SHARE_LINK_TYPE } from '../lib/share-link.js'
 
 describe('localGatewayToKuboGateway', () => {
   it('keeps an explicit port and treats http as insecure', () => {
@@ -39,5 +43,86 @@ describe('checkValidHttpUrl', () => {
     expect(checkValidHttpUrl('ftp://example.com')).toBe(false)
     expect(checkValidHttpUrl('not a url')).toBe(false)
     expect(checkValidHttpUrl('')).toBe(false)
+  })
+})
+
+const createMockIpfsBundle = (config) => ({
+  name: 'ipfs',
+  getExtraArgs: () => ({ getIpfs: () => ({ config: { getAll: async () => config } }) }),
+  selectIpfsReady: () => false,
+  selectIpfsConnected: () => false
+})
+
+const createStore = () => composeBundles(
+  createMockIpfsBundle({ Addresses: { Gateway: '/ip4/127.0.0.1/tcp/8080' } }),
+  gatewayBundle,
+  configBundle
+)()
+
+describe('gateway bundle actions', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('reverts the share link type to native when its public path gateway is cleared', async () => {
+    const store = createStore()
+    await store.doUpdatePublicGateway('https://path-gw.example.com')
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH)
+    expect(store.selectShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_PATH)
+    await store.doUpdatePublicGateway('')
+    expect(store.selectShareLinkType()).toBe(SHARE_LINK_TYPE.NATIVE)
+  })
+
+  it('does not revert when clearing a public gateway the type does not point at', async () => {
+    const store = createStore()
+    await store.doUpdatePublicSubdomainGateway('https://subdomain-gw.example.net')
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+    await store.doUpdatePublicGateway('') // clears the PATH gateway; type is SUBDOMAIN
+    expect(store.selectShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+  })
+
+  it('does not revert when saving a non-empty public gateway', async () => {
+    const store = createStore()
+    await store.doUpdatePublicGateway('https://a.example.com')
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH)
+    await store.doUpdatePublicGateway('https://b.example.com')
+    expect(store.selectShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_PATH)
+  })
+
+  it('doUpdateLocalGateway refreshes availableGateway, syncs kuboGateway, and flags the explorer reload', async () => {
+    const store = createStore()
+    await store.doUpdateLocalGateway('http://127.0.0.1:9999')
+    expect(store.selectExplorerNeedsReload()).toBe(true)
+    expect(store.selectAvailableGateway()).toBe('http://127.0.0.1:9999')
+    expect(readSetting('kuboGateway')).toEqual(localGatewayToKuboGateway('http://127.0.0.1:9999'))
+
+    await store.doUpdateLocalGateway('')
+    expect(readSetting('kuboGateway')).toEqual(DEFAULT_KUBO_GATEWAY)
+  })
+
+  it('normalizes a trailing slash on the stored local gateway', async () => {
+    const store = createStore()
+    await store.doUpdateLocalGateway('http://127.0.0.1:9999/')
+    expect(store.selectLocalGateway()).toBe('http://127.0.0.1:9999')
+  })
+
+  it('selectEffectiveShareLinkType stays native until the chosen public gateway is set', async () => {
+    const store = createStore()
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+    expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.NATIVE)
+    await store.doUpdatePublicSubdomainGateway('https://subdomain-gw.example.net')
+    expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+  })
+})
+
+describe('readShareLinkTypeSetting (via bundle init)', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('falls back to the default for a corrupted stored value', () => {
+    window.localStorage.setItem('ipfsShareLinkType', JSON.stringify('bogus'))
+    expect(createStore().selectShareLinkType()).toBe(DEFAULT_SHARE_LINK_TYPE)
+  })
+
+  it('preserves a valid stored value', () => {
+    window.localStorage.setItem('ipfsShareLinkType', JSON.stringify(SHARE_LINK_TYPE.LOCAL_PATH))
+    expect(createStore().selectShareLinkType()).toBe(SHARE_LINK_TYPE.LOCAL_PATH)
   })
 })

--- a/src/bundles/gateway.test.js
+++ b/src/bundles/gateway.test.js
@@ -104,6 +104,25 @@ describe('gateway bundle actions', () => {
     expect(store.selectLocalGateway()).toBe('http://127.0.0.1:9999')
   })
 
+  it('doUpdateLocalGateway is a no-op when the value is unchanged', async () => {
+    const store = createStore()
+    // Initial value is '': re-submitting it must not write settings or
+    // schedule an Explore reload.
+    await store.doUpdateLocalGateway('')
+    expect(store.selectExplorerNeedsReload()).toBe(false)
+    expect(readSetting('kuboGateway')).toBeFalsy()
+  })
+
+  it('selectEffectiveShareLinkType falls back to native for a local type with no local gateway', async () => {
+    const store = createStore()
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.LOCAL_PATH)
+    // The test store never fetches the Kubo config, so there is no local
+    // gateway at all until the override is set.
+    expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.NATIVE)
+    await store.doUpdateLocalGateway('http://127.0.0.1:9999')
+    expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.LOCAL_PATH)
+  })
+
   it('selectEffectiveShareLinkType stays native until the chosen public gateway is set', async () => {
     const store = createStore()
     await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)

--- a/src/bundles/gateway.test.js
+++ b/src/bundles/gateway.test.js
@@ -1,6 +1,6 @@
 /* global describe, it, expect, beforeEach */
 import { composeBundles } from 'redux-bundler'
-import gatewayBundle, { localGatewayToKuboGateway, checkValidHttpUrl, DEFAULT_KUBO_GATEWAY } from './gateway.js'
+import gatewayBundle, { localGatewayToKuboGateway, checkValidHttpUrl, DEFAULT_KUBO_GATEWAY, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY } from './gateway.js'
 import configBundle from './config.js'
 import { readSetting } from './local-storage.js'
 import { SHARE_LINK_TYPE, DEFAULT_SHARE_LINK_TYPE } from '../lib/share-link.js'
@@ -123,12 +123,40 @@ describe('gateway bundle actions', () => {
     expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.LOCAL_PATH)
   })
 
-  it('selectEffectiveShareLinkType stays native until the chosen public gateway is set', async () => {
+  it('selectEffectiveShareLinkType stays native while the chosen public gateway is cleared', async () => {
     const store = createStore()
+    await store.doUpdatePublicSubdomainGateway('')
     await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
     expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.NATIVE)
     await store.doUpdatePublicSubdomainGateway('https://subdomain-gw.example.net')
     expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+  })
+})
+
+describe('shipped defaults', () => {
+  beforeEach(() => window.localStorage.clear())
+
+  it('a fresh node has the public gateways prefilled and shares through the subdomain one', () => {
+    const store = createStore()
+    expect(store.selectPublicGateway()).toBe(DEFAULT_PATH_GATEWAY)
+    expect(store.selectPublicSubdomainGateway()).toBe(DEFAULT_SUBDOMAIN_GATEWAY)
+    expect(store.selectShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+    expect(store.selectEffectiveShareLinkType()).toBe(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+  })
+
+  it('a cleared public gateway stays cleared after a reload instead of reverting to the default', async () => {
+    await createStore().doUpdatePublicGateway('')
+    expect(createStore().selectPublicGateway()).toBe('')
+  })
+
+  it('selecting a public type persists the prefilled default gateway it points at', async () => {
+    const store = createStore()
+    expect(readSetting('ipfsPublicSubdomainGateway')).toBe(null)
+    expect(readSetting('ipfsPublicGateway')).toBe(null)
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)
+    expect(readSetting('ipfsPublicSubdomainGateway')).toBe(DEFAULT_SUBDOMAIN_GATEWAY)
+    await store.doUpdateShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH)
+    expect(readSetting('ipfsPublicGateway')).toBe(DEFAULT_PATH_GATEWAY)
   })
 })
 

--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -6,7 +6,7 @@ import { CID } from 'multiformats/cid'
 import all from 'it-all'
 
 import { readSetting, writeSetting } from './local-storage.js'
-import { safeSubresourceGwUrl } from '../lib/files.js'
+import { toLoopbackIpUrl } from '../lib/share-link.js'
 import { dispatchAsyncProvide } from './files/utils.js'
 
 // This bundle leverages createCacheBundle and persistActions for
@@ -40,11 +40,11 @@ const getRerenderAwareArray = (oldArray, newArray) => {
   return diff.length > 0 ? newArray : oldArray
 }
 
-const parseService = async (service, remoteServiceTemplates, ipfs) => {
-  const template = remoteServiceTemplates.find(t => service.endpoint.toString() === t.apiEndpoint.toString())
-  const icon = template?.icon
-  const visitServiceUrl = template?.visitServiceUrl
-  const parsedService = { ...service, name: service.service, icon, visitServiceUrl }
+// Template-derived fields (icon, visitServiceUrl) are joined in at read time
+// by selectPinningServices, so they follow gateway changes instead of freezing
+// whatever gateway was configured when the services were fetched.
+const parseService = async (service, ipfs) => {
+  const parsedService = { ...service, name: service.service }
 
   if (service?.stat?.status === 'invalid') {
     return { ...parsedService, numberOfPins: -1, online: false }
@@ -300,9 +300,8 @@ const pinningBundle = {
     dispatch({ type: 'SET_REMOTE_PINNING_SERVICES_AVAILABLE', payload: isPinRemotePresent })
     if (!isPinRemotePresent) return null
 
-    const remoteServiceTemplates = store.selectRemoteServiceTemplates()
     const offlineListOfServices = await ipfs.pin.remote.service.ls()
-    const remoteServices = await Promise.all(offlineListOfServices.map(service => parseService(service, remoteServiceTemplates, ipfs)))
+    const remoteServices = await Promise.all(offlineListOfServices.map(service => parseService(service, ipfs)))
     dispatch({ type: 'SET_REMOTE_PINNING_SERVICES', payload: remoteServices })
   },
 
@@ -313,23 +312,37 @@ const pinningBundle = {
     const isPinRemotePresent = (await ipfs.commands()).Subcommands.find(c => c.Name === 'pin').Subcommands.some(c => c.Name === 'remote')
     if (!isPinRemotePresent) return null
 
-    const remoteServiceTemplates = store.selectRemoteServiceTemplates()
     const servicesWithStats = await ipfs.pin.remote.service.ls({ stat: true })
-    const remoteServices = await Promise.all(servicesWithStats.map(service => parseService(service, remoteServiceTemplates, ipfs)))
+    const remoteServices = await Promise.all(servicesWithStats.map(service => parseService(service, ipfs)))
 
     dispatch({ type: 'SET_REMOTE_PINNING_SERVICES', payload: remoteServices })
   },
 
-  selectPinningServices: (state) => state.pinning.pinningServices || [],
+  selectPinningServicesRaw: (state) => state.pinning.pinningServices || [],
+
+  // Fetched services joined with their template's icon and service link at
+  // read time, so they follow the current gateway instead of freezing the one
+  // configured when the services were fetched.
+  selectPinningServices: createSelector(
+    'selectPinningServicesRaw',
+    'selectRemoteServiceTemplates',
+    (services, templates) => services.map(service => {
+      const template = templates.find(t => service.endpoint?.toString() === t.apiEndpoint.toString())
+      if (!template) return service
+      return { ...service, icon: template.icon, visitServiceUrl: template.visitServiceUrl }
+    })
+  ),
 
   // Resolve each provider icon against the available gateway (the same one file
   // previews use), so icons load from the local node instead of a hardcoded
-  // public gateway. safeSubresourceGwUrl keeps a localhost gateway loading over
-  // 127.0.0.1 to avoid the subdomain-redirect breakage (issue 2246).
+  // public gateway. toLoopbackIpUrl keeps a localhost gateway loading over
+  // 127.0.0.1 to avoid the subdomain-redirect breakage (issue 2246). With no
+  // gateway configured there is no icon, rather than a broken relative URL
+  // resolved against the WebUI origin.
   selectRemoteServiceTemplates: createSelector('selectAvailableGatewayUrl', (availableGatewayUrl) =>
     pinningServiceTemplates.map((template) => ({
       ...template,
-      icon: safeSubresourceGwUrl(`${availableGatewayUrl}/${template.iconPath}`)
+      icon: availableGatewayUrl ? toLoopbackIpUrl(`${availableGatewayUrl}/${template.iconPath}`) : ''
     }))
   ),
 

--- a/src/bundles/pinning.js
+++ b/src/bundles/pinning.js
@@ -1,10 +1,12 @@
 // @ts-check
+import { createSelector } from 'redux-bundler'
 import { pinningServiceTemplates } from '../constants/pinning.js'
 import memoize from 'p-memoize'
 import { CID } from 'multiformats/cid'
 import all from 'it-all'
 
 import { readSetting, writeSetting } from './local-storage.js'
+import { safeSubresourceGwUrl } from '../lib/files.js'
 import { dispatchAsyncProvide } from './files/utils.js'
 
 // This bundle leverages createCacheBundle and persistActions for
@@ -320,7 +322,16 @@ const pinningBundle = {
 
   selectPinningServices: (state) => state.pinning.pinningServices || [],
 
-  selectRemoteServiceTemplates: () => pinningServiceTemplates,
+  // Resolve each provider icon against the available gateway (the same one file
+  // previews use), so icons load from the local node instead of a hardcoded
+  // public gateway. safeSubresourceGwUrl keeps a localhost gateway loading over
+  // 127.0.0.1 to avoid the subdomain-redirect breakage (issue 2246).
+  selectRemoteServiceTemplates: createSelector('selectAvailableGatewayUrl', (availableGatewayUrl) =>
+    pinningServiceTemplates.map((template) => ({
+      ...template,
+      icon: safeSubresourceGwUrl(`${availableGatewayUrl}/${template.iconPath}`)
+    }))
+  ),
 
   selectArePinningServicesSupported: (state) => state.pinning.arePinningServicesSupported,
 

--- a/src/components/about-ipfs/AboutIpfs.js
+++ b/src/components/about-ipfs/AboutIpfs.js
@@ -18,7 +18,7 @@ export const AboutIpfs = ({ t }) => {
           <li className='mb2'><strong>A peer-to-peer file transfer network</strong> with a completely decentralized architecture and no central point of failure, censorship, or control</li>
         </Trans>
         <Trans i18nKey='aboutIpfs.paragraph3' t={t}>
-          <li className='mb2'><strong>An on-ramp to tomorrow's web</strong> &mdash; traditional browsers can access IPFS files through gateways like <code className='f5 bg-light-gray br2 pa1'>https://dweb.link</code> or directly using the <a className='link blue' target='_blank' rel='noopener noreferrer' href='https://github.com/ipfs/ipfs-companion#readme'>IFPS Companion</a> extension</li>
+          <li className='mb2'><strong>An on-ramp to tomorrow's web</strong>: traditional browsers can access IPFS content through an HTTP gateway, or directly with the <a className='link blue' target='_blank' rel='noopener noreferrer' href='https://github.com/ipfs/ipfs-companion#readme'>IPFS Companion</a> extension</li>
         </Trans>
         <Trans i18nKey='aboutIpfs.paragraph4' t={t}>
           <li className='mb2'><strong>A next-gen CDN</strong> &mdash; just add a file to your node to make it available to the world with cache-friendly content-hash addressing and BitTorrent-style bandwidth distribution</li>

--- a/src/components/api-address-form/api-address-form.tsx
+++ b/src/components/api-address-form/api-address-form.tsx
@@ -68,7 +68,7 @@ const ApiAddressForm: React.FC<ApiAddressFormProps> = ({ checkValidAPIAddress = 
         aria-label={t('terms.apiAddress')}
         placeholder={t('apiAddressForm.placeholder')}
         type='text'
-        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
         onChange={onChange}
         onKeyDown={onKeyDown}
         value={value}

--- a/src/components/gateway-form/GatewayForm.js
+++ b/src/components/gateway-form/GatewayForm.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react'
+import Button from '../button/button.tsx'
+import { checkValidHttpUrl } from '../../bundles/gateway.js'
+
+/**
+ * Text input with Clear/Submit buttons for a gateway URL setting. We validate
+ * the URL format only and trust the user's choice, so a private, offline, or
+ * reverse-proxy gateway is not rejected. Empty is valid: it clears the setting
+ * so the caller's fallback applies (e.g. the Kubo config gateway, or a native
+ * ipfs:// share link).
+ */
+const GatewayForm = ({ t, savedValue, onUpdate, inputId, clearButtonId, submitButtonId, ariaLabel, placeholder }) => {
+  const [value, setValue] = useState(savedValue)
+  const isValid = value === '' || checkValidHttpUrl(value)
+
+  const onSubmit = (event) => {
+    event.preventDefault()
+    if (!isValid) return
+    onUpdate(value)
+  }
+
+  const onClear = (event) => {
+    event.preventDefault()
+    setValue('')
+    onUpdate('')
+  }
+
+  const onKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      onSubmit(event)
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit}>
+      <input
+        id={inputId}
+        aria-label={ariaLabel}
+        placeholder={placeholder}
+        type='text'
+        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${isValid ? 'focus-outline-green b--green-muted' : 'focus-outline-red b--red-muted'}`}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyPress={onKeyPress}
+        value={value}
+      />
+      <div className='tr'>
+        <Button
+          id={clearButtonId}
+          minWidth={100}
+          height={40}
+          bg='bg-charcoal'
+          className='tc'
+          disabled={value === ''}
+          onClick={onClear}>
+          {t('app:actions.clear')}
+        </Button>
+        <Button
+          id={submitButtonId}
+          minWidth={100}
+          height={40}
+          className='mt2 mt0-l ml2 tc'
+          disabled={!isValid || value === savedValue}>
+          {t('actions.submit')}
+        </Button>
+      </div>
+    </form>
+  )
+}
+
+export default GatewayForm

--- a/src/components/ipns-manager/IpnsManager.js
+++ b/src/components/ipns-manager/IpnsManager.js
@@ -1,6 +1,7 @@
 import React, { Fragment, useState, useRef, useMemo, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { sortByProperty } from '../../lib/sort.js'
+import { getLocalContentLink, toIpnsBase36 } from '../../lib/share-link.js'
 import { AutoSizer, Table, Column, SortDirection } from 'react-virtualized'
 
 // Components
@@ -53,7 +54,7 @@ const OptionsCell = ({ t, name, showRenameKeyModal, showRemoveKeyModal }) => {
   )
 }
 
-export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, doRenameIpnsKey, doRemoveIpnsKey, availableGatewayUrl, ipnsKeys }) => {
+export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, doRenameIpnsKey, doRemoveIpnsKey, localGatewayUrl, publicGateway, shareLinkType, ipnsKeys }) => {
   const [isGenerateKeyModalOpen, setGenerateKeyModalOpen] = useState(false)
   const showGenerateKeyModal = () => setGenerateKeyModalOpen(true)
   const hideGenerateKeyModal = () => setGenerateKeyModalOpen(false)
@@ -80,6 +81,19 @@ export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, 
   const sortedKeys = useMemo(() =>
     (ipnsKeys || []).sort(sortByProperty(sortSettings.sortBy, sortSettings.sortDirection === SortDirection.ASC ? 1 : -1)),
   [ipnsKeys, sortSettings.sortBy, sortSettings.sortDirection])
+
+  // Local gateway link honoring the Share Link type from Settings (subdomain
+  // origin when chosen), falling back to the public gateway, or no link at all.
+  const ipnsUrl = (id) => {
+    const ipnsName = toIpnsBase36(id)
+    return getLocalContentLink({
+      shareLinkType,
+      namespace: 'ipns',
+      pathId: ipnsName,
+      subdomainLabel: ipnsName,
+      localGatewayUrl
+    }) || (publicGateway ? `${publicGateway}/ipns/${ipnsName}` : '')
+  }
 
   return (
     <Fragment>
@@ -116,11 +130,13 @@ export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, 
                   width={width * 0.6}
                   className='charcoal monospace truncate f6 pl2'
                   flexShrink={1}
-                  cellRenderer={({ rowData }) => (
-                    rowData.published
-                      ? <a href={`${availableGatewayUrl}/ipns/${rowData.id}`} target='_blank' rel='noopener noreferrer' className='link blue'>{rowData.id}</a>
+                  cellRenderer={({ rowData }) => {
+                    if (!rowData.published) return rowData.id
+                    const url = ipnsUrl(rowData.id)
+                    return url
+                      ? <a href={url} target='_blank' rel='noopener noreferrer' className='link blue'>{rowData.id}</a>
                       : rowData.id
-                  )} />
+                  }} />
                 <Column
                   dataKey='options'
                   width={width * 0.1}
@@ -184,7 +200,9 @@ IpnsManager.defaultProps = {
 export default connect(
   'selectIpfsReady',
   'selectIpnsKeys',
-  'selectAvailableGatewayUrl',
+  'selectLocalGatewayUrl',
+  'selectPublicGateway',
+  'selectShareLinkType',
   'doFetchIpnsKeys',
   'doGenerateIpnsKey',
   'doRemoveIpnsKey',

--- a/src/components/local-gateway-form/LocalGatewayForm.js
+++ b/src/components/local-gateway-form/LocalGatewayForm.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import Button from '../button/button.tsx'
-import { checkValidHttpUrl, checkViaImgSrc } from '../../bundles/gateway.js'
+import { checkValidHttpUrl } from '../../bundles/gateway.js'
 
 const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
   // Empty value is valid: it means "use the gateway address from Kubo config".
@@ -18,19 +18,11 @@ const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
 
   const onChange = (event) => setValue(event.target.value)
 
-  const onSubmit = async (event) => {
+  const onSubmit = (event) => {
     event.preventDefault()
     if (!isValid) return
-    // A non-empty override must be reachable from the browser, otherwise it
-    // would silently break download and preview links with no fallback.
-    if (value !== '') {
-      try {
-        await checkViaImgSrc(value)
-      } catch (e) {
-        setShowFailState(true)
-        return
-      }
-    }
+    // We validate the URL format only and trust the user's choice, so a private
+    // or reverse-proxy gateway (the reason this override exists) is not rejected.
     doUpdateLocalGateway(value)
   }
 
@@ -55,7 +47,7 @@ const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
         aria-label={t('terms.localGateway')}
         placeholder={t('localGatewayForm.placeholder', 'Enter a URL (http://localhost:8080)')}
         type='text'
-        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
         onChange={onChange}
         onKeyPress={onKeyPress}
         value={value}
@@ -75,7 +67,7 @@ const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
           id='local-gateway-submit-button'
           minWidth={100}
           height={40}
-          className='mt2 mt0-l ml2-l tc'
+          className='mt2 mt0-l ml2 tc'
           disabled={!isValid || !hasChanges}>
           {t('actions.submit')}
         </Button>

--- a/src/components/local-gateway-form/LocalGatewayForm.js
+++ b/src/components/local-gateway-form/LocalGatewayForm.js
@@ -1,80 +1,21 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
-import Button from '../button/button.tsx'
-import { checkValidHttpUrl } from '../../bundles/gateway.js'
+import GatewayForm from '../gateway-form/GatewayForm.js'
 
-const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
-  // Empty value is valid: it means "use the gateway address from Kubo config".
-  const [value, setValue] = useState(localGateway)
-  const [isValid, setIsValid] = useState(localGateway === '' || checkValidHttpUrl(localGateway))
-  const [showFailState, setShowFailState] = useState(!(localGateway === '' || checkValidHttpUrl(localGateway)))
-
-  useEffect(() => {
-    const valid = value === '' || checkValidHttpUrl(value)
-    setIsValid(valid)
-    setShowFailState(!valid)
-  }, [value])
-
-  const onChange = (event) => setValue(event.target.value)
-
-  const onSubmit = (event) => {
-    event.preventDefault()
-    if (!isValid) return
-    // We validate the URL format only and trust the user's choice, so a private
-    // or reverse-proxy gateway (the reason this override exists) is not rejected.
-    doUpdateLocalGateway(value)
-  }
-
-  const onClear = async (event) => {
-    event.preventDefault()
-    setValue('')
-    doUpdateLocalGateway('')
-  }
-
-  const onKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      onSubmit(event)
-    }
-  }
-
-  const hasChanges = value !== localGateway
-
-  return (
-    <form onSubmit={onSubmit}>
-      <input
-        id='local-gateway'
-        aria-label={t('terms.localGateway')}
-        placeholder={t('localGatewayForm.placeholder', 'Enter a URL (http://localhost:8080)')}
-        type='text'
-        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
-        onChange={onChange}
-        onKeyPress={onKeyPress}
-        value={value}
-      />
-      <div className='tr'>
-        <Button
-          id='local-gateway-clear-button'
-          minWidth={100}
-          height={40}
-          bg='bg-charcoal'
-          className='tc'
-          disabled={value === ''}
-          onClick={onClear}>
-          {t('app:actions.clear')}
-        </Button>
-        <Button
-          id='local-gateway-submit-button'
-          minWidth={100}
-          height={40}
-          className='mt2 mt0-l ml2 tc'
-          disabled={!isValid || !hasChanges}>
-          {t('actions.submit')}
-        </Button>
-      </div>
-    </form>
-  )
-}
+// Empty clears the override: the gateway address from the Kubo config applies.
+const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => (
+  <GatewayForm
+    t={t}
+    savedValue={localGateway}
+    onUpdate={doUpdateLocalGateway}
+    inputId='local-gateway'
+    clearButtonId='local-gateway-clear-button'
+    submitButtonId='local-gateway-submit-button'
+    ariaLabel={t('terms.localGateway')}
+    placeholder={t('localGatewayForm.placeholder', 'Enter a URL (http://localhost:8080)')}
+  />
+)
 
 export default connect(
   'doUpdateLocalGateway',

--- a/src/components/public-gateway-form/PublicGatewayForm.js
+++ b/src/components/public-gateway-form/PublicGatewayForm.js
@@ -2,45 +2,33 @@ import React, { useState, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import Button from '../button/button.tsx'
-import { checkValidHttpUrl, checkViaImgSrc, DEFAULT_PATH_GATEWAY } from '../../bundles/gateway.js'
+import { checkValidHttpUrl } from '../../bundles/gateway.js'
 
 const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => {
+  // We validate the URL format only and trust the user's choice, so a private or
+  // offline gateway is not rejected. Empty is valid: it clears the gateway, and
+  // Share Links for those CIDs fall back to a native ipfs:// URI.
   const [value, setValue] = useState(publicGateway)
-  const initialIsValidGatewayUrl = !checkValidHttpUrl(value)
-  const [showFailState, setShowFailState] = useState(initialIsValidGatewayUrl)
-  const [isValidGatewayUrl, setIsValidGatewayUrl] = useState(initialIsValidGatewayUrl)
+  const isValidGatewayUrl = value === '' || checkValidHttpUrl(value)
+  const [showFailState, setShowFailState] = useState(!isValidGatewayUrl)
 
   // Updates the border of the input to indicate validity
   useEffect(() => {
-    setShowFailState(!isValidGatewayUrl)
-  }, [isValidGatewayUrl])
-
-  // Updates the border of the input to indicate validity
-  useEffect(() => {
-    const isValid = checkValidHttpUrl(value)
-    setIsValidGatewayUrl(isValid)
-    setShowFailState(!isValid)
+    setShowFailState(!(value === '' || checkValidHttpUrl(value)))
   }, [value])
 
   const onChange = (event) => setValue(event.target.value)
 
-  const onSubmit = async (event) => {
+  const onSubmit = (event) => {
     event.preventDefault()
-
-    try {
-      await checkViaImgSrc(value)
-    } catch (e) {
-      setShowFailState(true)
-      return
-    }
-
+    if (!isValidGatewayUrl) return
     doUpdatePublicGateway(value)
   }
 
-  const onReset = async (event) => {
+  const onClear = async (event) => {
     event.preventDefault()
-    setValue(DEFAULT_PATH_GATEWAY)
-    doUpdatePublicGateway(DEFAULT_PATH_GATEWAY)
+    setValue('')
+    doUpdatePublicGateway('')
   }
 
   const onKeyPress = (event) => {
@@ -56,27 +44,27 @@ const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => {
         aria-label={t('terms.publicGateway')}
         placeholder={t('publicGatewayForm.placeholder')}
         type='text'
-        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
         onChange={onChange}
         onKeyPress={onKeyPress}
         value={value}
       />
       <div className='tr'>
         <Button
-          id='public-path-gateway-reset-button'
+          id='public-path-gateway-clear-button'
           minWidth={100}
           height={40}
           bg='bg-charcoal'
           className='tc'
-          disabled={value === DEFAULT_PATH_GATEWAY}
-          onClick={onReset}>
-          {t('app:actions.reset')}
+          disabled={value === ''}
+          onClick={onClear}>
+          {t('app:actions.clear')}
         </Button>
         <Button
           id='public-path-gateway-submit-button'
           minWidth={100}
           height={40}
-          className='mt2 mt0-l ml2-l tc'
+          className='mt2 mt0-l ml2 tc'
           disabled={!isValidGatewayUrl || value === publicGateway}>
           {t('actions.submit')}
         </Button>

--- a/src/components/public-gateway-form/PublicGatewayForm.js
+++ b/src/components/public-gateway-form/PublicGatewayForm.js
@@ -1,77 +1,21 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
-import Button from '../button/button.tsx'
-import { checkValidHttpUrl } from '../../bundles/gateway.js'
+import GatewayForm from '../gateway-form/GatewayForm.js'
 
-const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => {
-  // We validate the URL format only and trust the user's choice, so a private or
-  // offline gateway is not rejected. Empty is valid: it clears the gateway, and
-  // Share Links for those CIDs fall back to a native ipfs:// URI.
-  const [value, setValue] = useState(publicGateway)
-  const isValidGatewayUrl = value === '' || checkValidHttpUrl(value)
-  const [showFailState, setShowFailState] = useState(!isValidGatewayUrl)
-
-  // Updates the border of the input to indicate validity
-  useEffect(() => {
-    setShowFailState(!(value === '' || checkValidHttpUrl(value)))
-  }, [value])
-
-  const onChange = (event) => setValue(event.target.value)
-
-  const onSubmit = (event) => {
-    event.preventDefault()
-    if (!isValidGatewayUrl) return
-    doUpdatePublicGateway(value)
-  }
-
-  const onClear = async (event) => {
-    event.preventDefault()
-    setValue('')
-    doUpdatePublicGateway('')
-  }
-
-  const onKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      onSubmit(event)
-    }
-  }
-
-  return (
-    <form onSubmit={onSubmit}>
-      <input
-        id='public-gateway'
-        aria-label={t('terms.publicGateway')}
-        placeholder={t('publicGatewayForm.placeholder')}
-        type='text'
-        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
-        onChange={onChange}
-        onKeyPress={onKeyPress}
-        value={value}
-      />
-      <div className='tr'>
-        <Button
-          id='public-path-gateway-clear-button'
-          minWidth={100}
-          height={40}
-          bg='bg-charcoal'
-          className='tc'
-          disabled={value === ''}
-          onClick={onClear}>
-          {t('app:actions.clear')}
-        </Button>
-        <Button
-          id='public-path-gateway-submit-button'
-          minWidth={100}
-          height={40}
-          className='mt2 mt0-l ml2 tc'
-          disabled={!isValidGatewayUrl || value === publicGateway}>
-          {t('actions.submit')}
-        </Button>
-      </div>
-    </form>
-  )
-}
+// Empty clears the gateway; Share Links then fall back to a native ipfs:// URI.
+const PublicGatewayForm = ({ t, doUpdatePublicGateway, publicGateway }) => (
+  <GatewayForm
+    t={t}
+    savedValue={publicGateway}
+    onUpdate={doUpdatePublicGateway}
+    inputId='public-gateway'
+    clearButtonId='public-path-gateway-clear-button'
+    submitButtonId='public-path-gateway-submit-button'
+    ariaLabel={t('terms.publicGateway')}
+    placeholder={t('publicGatewayForm.placeholder')}
+  />
+)
 
 export default connect(
   'doUpdatePublicGateway',

--- a/src/components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js
+++ b/src/components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js
@@ -2,49 +2,33 @@ import React, { useState, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import Button from '../button/button.tsx'
-import { checkValidHttpUrl, checkSubdomainGateway, DEFAULT_SUBDOMAIN_GATEWAY } from '../../bundles/gateway.js'
+import { checkValidHttpUrl } from '../../bundles/gateway.js'
 
 const PublicSubdomainGatewayForm = ({ t, doUpdatePublicSubdomainGateway, publicSubdomainGateway }) => {
+  // We validate the URL format only and trust the user's choice, so a private or
+  // offline gateway is not rejected. Empty is valid: it clears the gateway, and
+  // Share Links fall back to a native ipfs:// URI.
   const [value, setValue] = useState(publicSubdomainGateway)
-  const initialIsValidGatewayUrl = !checkValidHttpUrl(value)
-  const [isValidGatewayUrl, setIsValidGatewayUrl] = useState(initialIsValidGatewayUrl)
+  const isValidGatewayUrl = value === '' || checkValidHttpUrl(value)
+  const [showFailState, setShowFailState] = useState(!isValidGatewayUrl)
 
   // Updates the border of the input to indicate validity
   useEffect(() => {
-    const validateUrl = async () => {
-      try {
-        const isValid = await checkSubdomainGateway(value)
-        setIsValidGatewayUrl(isValid)
-      } catch (error) {
-        console.error('Error checking subdomain gateway:', error)
-        setIsValidGatewayUrl(false)
-      }
-    }
-
-    validateUrl()
+    setShowFailState(!(value === '' || checkValidHttpUrl(value)))
   }, [value])
 
   const onChange = (event) => setValue(event.target.value)
 
-  const onSubmit = async (event) => {
+  const onSubmit = (event) => {
     event.preventDefault()
-
-    let isValid = false
-    try {
-      isValid = await checkSubdomainGateway(value)
-      setIsValidGatewayUrl(true)
-    } catch (e) {
-      setIsValidGatewayUrl(false)
-      return
-    }
-
-    isValid && doUpdatePublicSubdomainGateway(value)
+    if (!isValidGatewayUrl) return
+    doUpdatePublicSubdomainGateway(value)
   }
 
-  const onReset = async (event) => {
+  const onClear = (event) => {
     event.preventDefault()
-    setValue(DEFAULT_SUBDOMAIN_GATEWAY)
-    doUpdatePublicSubdomainGateway(DEFAULT_SUBDOMAIN_GATEWAY)
+    setValue('')
+    doUpdatePublicSubdomainGateway('')
   }
 
   const onKeyPress = (event) => {
@@ -60,27 +44,27 @@ const PublicSubdomainGatewayForm = ({ t, doUpdatePublicSubdomainGateway, publicS
         aria-label={t('terms.publicSubdomainGateway')}
         placeholder={t('publicSubdomainGatewayForm.placeholder')}
         type='text'
-        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${!isValidGatewayUrl ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
         onChange={onChange}
         onKeyPress={onKeyPress}
         value={value}
       />
       <div className='tr'>
         <Button
-          id='public-subdomain-gateway-reset-button'
+          id='public-subdomain-gateway-clear-button'
           minWidth={100}
           height={40}
           bg='bg-charcoal'
           className='tc'
-          disabled={value === DEFAULT_SUBDOMAIN_GATEWAY}
-          onClick={onReset}>
-          {t('app:actions.reset')}
+          disabled={value === ''}
+          onClick={onClear}>
+          {t('app:actions.clear')}
         </Button>
         <Button
           id='public-subdomain-gateway-submit-button'
           minWidth={100}
           height={40}
-          className='mt2 mt0-l ml2-l tc'
+          className='mt2 mt0-l ml2 tc'
           disabled={!isValidGatewayUrl || value === publicSubdomainGateway}>
           {t('actions.submit')}
         </Button>

--- a/src/components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js
+++ b/src/components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js
@@ -1,77 +1,21 @@
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
-import Button from '../button/button.tsx'
-import { checkValidHttpUrl } from '../../bundles/gateway.js'
+import GatewayForm from '../gateway-form/GatewayForm.js'
 
-const PublicSubdomainGatewayForm = ({ t, doUpdatePublicSubdomainGateway, publicSubdomainGateway }) => {
-  // We validate the URL format only and trust the user's choice, so a private or
-  // offline gateway is not rejected. Empty is valid: it clears the gateway, and
-  // Share Links fall back to a native ipfs:// URI.
-  const [value, setValue] = useState(publicSubdomainGateway)
-  const isValidGatewayUrl = value === '' || checkValidHttpUrl(value)
-  const [showFailState, setShowFailState] = useState(!isValidGatewayUrl)
-
-  // Updates the border of the input to indicate validity
-  useEffect(() => {
-    setShowFailState(!(value === '' || checkValidHttpUrl(value)))
-  }, [value])
-
-  const onChange = (event) => setValue(event.target.value)
-
-  const onSubmit = (event) => {
-    event.preventDefault()
-    if (!isValidGatewayUrl) return
-    doUpdatePublicSubdomainGateway(value)
-  }
-
-  const onClear = (event) => {
-    event.preventDefault()
-    setValue('')
-    doUpdatePublicSubdomainGateway('')
-  }
-
-  const onKeyPress = (event) => {
-    if (event.key === 'Enter') {
-      onSubmit(event)
-    }
-  }
-
-  return (
-    <form onSubmit={onSubmit}>
-      <input
-        id='public-subdomain-gateway'
-        aria-label={t('terms.publicSubdomainGateway')}
-        placeholder={t('publicSubdomainGatewayForm.placeholder')}
-        type='text'
-        className={`w-100 lh-copy monospace f5 pa2 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
-        onChange={onChange}
-        onKeyPress={onKeyPress}
-        value={value}
-      />
-      <div className='tr'>
-        <Button
-          id='public-subdomain-gateway-clear-button'
-          minWidth={100}
-          height={40}
-          bg='bg-charcoal'
-          className='tc'
-          disabled={value === ''}
-          onClick={onClear}>
-          {t('app:actions.clear')}
-        </Button>
-        <Button
-          id='public-subdomain-gateway-submit-button'
-          minWidth={100}
-          height={40}
-          className='mt2 mt0-l ml2 tc'
-          disabled={!isValidGatewayUrl || value === publicSubdomainGateway}>
-          {t('actions.submit')}
-        </Button>
-      </div>
-    </form>
-  )
-}
+// Empty clears the gateway; Share Links then fall back to a native ipfs:// URI.
+const PublicSubdomainGatewayForm = ({ t, doUpdatePublicSubdomainGateway, publicSubdomainGateway }) => (
+  <GatewayForm
+    t={t}
+    savedValue={publicSubdomainGateway}
+    onUpdate={doUpdatePublicSubdomainGateway}
+    inputId='public-subdomain-gateway'
+    clearButtonId='public-subdomain-gateway-clear-button'
+    submitButtonId='public-subdomain-gateway-submit-button'
+    ariaLabel={t('terms.publicSubdomainGateway')}
+    placeholder={t('publicSubdomainGatewayForm.placeholder')}
+  />
+)
 
 export default connect(
   'doUpdatePublicSubdomainGateway',

--- a/src/components/share-link-type-form/ShareLinkTypeForm.js
+++ b/src/components/share-link-type-form/ShareLinkTypeForm.js
@@ -20,17 +20,21 @@ const GATEWAY_OPTIONS = [
   { value: SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN, key: 'publicSubdomain', subdomain: true, isolation: true, Form: PublicSubdomainGatewayForm }
 ]
 
-const ShareLinkTypeForm = ({ t, shareLinkType, gatewayUrl, publicGateway, publicSubdomainGateway, doUpdateShareLinkType }) => {
-  // A public option cannot be chosen until its gateway is configured below it.
+const ShareLinkTypeForm = ({ t, shareLinkType, localGatewayUrl, publicGateway, publicSubdomainGateway, doUpdateShareLinkType }) => {
+  // An option cannot be chosen until its gateway is configured: the public
+  // ones via the forms below them, the local ones via the Local Gateway URL
+  // section or the Kubo config.
   const disabledFor = {
+    [SHARE_LINK_TYPE.LOCAL_PATH]: !localGatewayUrl,
+    [SHARE_LINK_TYPE.LOCAL_SUBDOMAIN]: !localGatewayUrl,
     [SHARE_LINK_TYPE.PUBLIC_PATH]: !publicGateway,
     [SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN]: !publicSubdomainGateway
   }
 
   // The gateway each option's example is drawn from; native has none.
   const gatewayUrlFor = {
-    [SHARE_LINK_TYPE.LOCAL_PATH]: gatewayUrl,
-    [SHARE_LINK_TYPE.LOCAL_SUBDOMAIN]: gatewayUrl,
+    [SHARE_LINK_TYPE.LOCAL_PATH]: localGatewayUrl,
+    [SHARE_LINK_TYPE.LOCAL_SUBDOMAIN]: localGatewayUrl,
     [SHARE_LINK_TYPE.PUBLIC_PATH]: publicGateway,
     [SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN]: publicSubdomainGateway
   }
@@ -103,7 +107,7 @@ const ShareLinkTypeForm = ({ t, shareLinkType, gatewayUrl, publicGateway, public
 
 export default connect(
   'selectShareLinkType',
-  'selectGatewayUrl',
+  'selectLocalGatewayUrl',
   'selectPublicGateway',
   'selectPublicSubdomainGateway',
   'doUpdateShareLinkType',

--- a/src/components/share-link-type-form/ShareLinkTypeForm.js
+++ b/src/components/share-link-type-form/ShareLinkTypeForm.js
@@ -1,0 +1,111 @@
+import React from 'react'
+import { connect } from 'redux-bundler-react'
+import { withTranslation, Trans } from 'react-i18next'
+import Radio from '../radio/radio.tsx'
+import PublicGatewayForm from '../public-gateway-form/PublicGatewayForm.js'
+import PublicSubdomainGatewayForm from '../public-subdomain-gateway-form/PublicSubdomainGatewayForm.js'
+import { SHARE_LINK_TYPE, gatewayExample } from '../../lib/share-link.js'
+
+const COMPANION_URL = 'https://docs.ipfs.tech/install/ipfs-companion/'
+const GATEWAY_CHECKER_URL = 'https://ipfs.github.io/public-gateway-checker/'
+const SELF_HOST_URL = 'https://docs.ipfs.tech/how-to/replace-public-gateways-with-self-hosted-ipfs/'
+const ORIGIN_ISOLATION_URL = 'https://developer.mozilla.org/en-US/docs/Web/Security/Same-origin_policy'
+
+// Native first (recommended), then the gateway options grouped after it.
+const NATIVE_OPTION = { value: SHARE_LINK_TYPE.NATIVE, key: 'native', recommended: true, companion: true }
+const GATEWAY_OPTIONS = [
+  { value: SHARE_LINK_TYPE.LOCAL_PATH, key: 'localPath', subdomain: false },
+  { value: SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, key: 'localSubdomain', subdomain: true, isolation: true },
+  { value: SHARE_LINK_TYPE.PUBLIC_PATH, key: 'publicPath', subdomain: false, Form: PublicGatewayForm },
+  { value: SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN, key: 'publicSubdomain', subdomain: true, isolation: true, Form: PublicSubdomainGatewayForm }
+]
+
+const ShareLinkTypeForm = ({ t, shareLinkType, gatewayUrl, publicGateway, publicSubdomainGateway, doUpdateShareLinkType }) => {
+  // A public option cannot be chosen until its gateway is configured below it.
+  const disabledFor = {
+    [SHARE_LINK_TYPE.PUBLIC_PATH]: !publicGateway,
+    [SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN]: !publicSubdomainGateway
+  }
+
+  // The gateway each option's example is drawn from; native has none.
+  const gatewayUrlFor = {
+    [SHARE_LINK_TYPE.LOCAL_PATH]: gatewayUrl,
+    [SHARE_LINK_TYPE.LOCAL_SUBDOMAIN]: gatewayUrl,
+    [SHARE_LINK_TYPE.PUBLIC_PATH]: publicGateway,
+    [SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN]: publicSubdomainGateway
+  }
+
+  const renderOption = ({ value, key, recommended, companion, isolation, subdomain, Form }) => {
+    const disabled = Boolean(disabledFor[value])
+    const checked = shareLinkType === value
+    const exampleUrl = gatewayUrlFor[value]
+    const example = exampleUrl ? gatewayExample(exampleUrl, { subdomain }) : ''
+    return (
+      <div key={value} className='mv3'>
+        <div className={disabled ? 'o-40' : ''}>
+          <Radio
+            checked={checked}
+            disabled={disabled}
+            onChange={(isChecked) => { if (isChecked && !disabled) doUpdateShareLinkType(value) }}
+            label={
+              <span className='f6 fw6 charcoal'>
+                {t(`shareLink.${key}.label`)}
+                { recommended &&
+                  <span className='dib ml2 ph2 pv1 f6 fw6 white bg-teal br2'>{t('shareLink.recommendedBadge')}</span> }
+              </span>
+            }
+          />
+          <p className='ma0 mt1 ml4 f6 charcoal-muted lh-copy'>{t(`shareLink.${key}.description`)}</p>
+          { example &&
+            <p className='ma0 mt1 ml4 f6 charcoal-muted lh-copy'>
+              {t('shareLink.usesGateway')} <code className='f6 charcoal'>{example}</code>
+            </p> }
+          { companion &&
+            <p className='ma0 mt1 ml4 f6 charcoal-muted lh-copy'>
+              <Trans i18nKey='shareLink.native.companionNote' t={t}>
+                <a className='link blue' href={COMPANION_URL} target='_blank' rel='noopener noreferrer'>IPFS Companion</a>
+              </Trans>
+            </p> }
+          { isolation &&
+            <p className='ma0 mt1 ml4 f6 charcoal-muted lh-copy'>
+              <Trans i18nKey='shareLink.subdomainNote' t={t}>
+                <a className='link blue' href={ORIGIN_ISOLATION_URL} target='_blank' rel='noopener noreferrer'>how browsers keep sites apart</a>
+              </Trans>
+            </p> }
+        </div>
+        { Form &&
+          <div className='ml4 mt2'>
+            { disabled &&
+              <p className='ma0 mb2 f6 charcoal-muted lh-copy'>{t('shareLink.publicGatewayEmptyHint')}</p> }
+            <Form />
+          </div> }
+      </div>
+    )
+  }
+
+  // A plain div, not a form: the nested public gateway forms are real <form>
+  // elements and forms cannot be nested. Radios apply on change, so no submit.
+  return (
+    <div>
+      {renderOption(NATIVE_OPTION)}
+      <p className='mt3 mb1 f6 fw6 charcoal'>{t('shareLink.gatewayGroupTitle')}</p>
+      <p className='ma0 mb0 f6 charcoal-muted lh-copy'>{t('shareLink.gatewayGroupNote')}</p>
+      {GATEWAY_OPTIONS.map(renderOption)}
+      <p className='ma0 mt3 f6 charcoal-muted lh-copy'>
+        <Trans i18nKey='shareLink.publicGatewayHelp' t={t}>
+          <a className='link blue' href={GATEWAY_CHECKER_URL} target='_blank' rel='noopener noreferrer'>Public Gateway Checker</a>
+          <a className='link blue' href={SELF_HOST_URL} target='_blank' rel='noopener noreferrer'>run your own</a>
+        </Trans>
+      </p>
+    </div>
+  )
+}
+
+export default connect(
+  'selectShareLinkType',
+  'selectGatewayUrl',
+  'selectPublicGateway',
+  'selectPublicSubdomainGateway',
+  'doUpdateShareLinkType',
+  withTranslation('settings')(ShareLinkTypeForm)
+)

--- a/src/constants/pinning.ts
+++ b/src/constants/pinning.ts
@@ -8,7 +8,9 @@ const complianceReportsHomepage = 'https://ipfs-shipyard.github.io/pinning-servi
 
 interface PinningServiceTemplate {
   name: string
-  icon: string
+  // Gateway-relative path to the provider icon (no host), resolved against the
+  // available gateway at render time so it loads the same way as file previews.
+  iconPath: string
   apiEndpoint: string
   visitServiceUrl: string
   complianceReportUrl?: string
@@ -26,25 +28,25 @@ interface SortablePinningServiceTemplate {
 const pinningServiceTemplates: PinningServiceTemplate[] = [
   {
     name: 'Pinata',
-    icon: 'https://dweb.link/ipfs/QmVYXV4urQNDzZpddW4zZ9PGvcAbF38BnKWSgch3aNeViW?filename=pinata.svg',
+    iconPath: 'ipfs/QmVYXV4urQNDzZpddW4zZ9PGvcAbF38BnKWSgch3aNeViW?filename=pinata.svg',
     apiEndpoint: 'https://api.pinata.cloud/psa',
     visitServiceUrl: 'https://docs.pinata.cloud/api-reference/pinning-service-api'
   },
   {
     name: 'Filebase',
-    icon: 'https://dweb.link/ipfs/QmWBaeu6y1zEcKbsEqCuhuDHPL3W8pZouCPdafMCRCSUWk?filename=filebase.png',
+    iconPath: 'ipfs/QmWBaeu6y1zEcKbsEqCuhuDHPL3W8pZouCPdafMCRCSUWk?filename=filebase.png',
     apiEndpoint: 'https://api.filebase.io/v1/ipfs',
     visitServiceUrl: 'https://docs.filebase.com/api-documentation/ipfs-pinning-service-api'
   },
   {
     name: 'Functionland',
-    icon: 'https://dweb.link/ipfs/QmWYEmdYq9Ry2xtb69oZSPXb8Aos24kWdVecsT3txVe38E?filename=functionland.svg',
+    iconPath: 'ipfs/QmWYEmdYq9Ry2xtb69oZSPXb8Aos24kWdVecsT3txVe38E?filename=functionland.svg',
     apiEndpoint: 'https://api.cloud.fx.land',
     visitServiceUrl: 'https://docs.fx.land/pinning-service/ipfs-pinning-service-api'
   },
   {
     name: '4EVERLAND',
-    icon: 'https://dweb.link/ipfs/bafkreie4mg2rmoe6fzct4rpwd2d4nuok3yx2mew567nu3s5bfnnmlb65ei?filename=4everland-logo.svg',
+    iconPath: 'ipfs/bafkreie4mg2rmoe6fzct4rpwd2d4nuok3yx2mew567nu3s5bfnnmlb65ei?filename=4everland-logo.svg',
     apiEndpoint: 'https://api.4everland.dev',
     visitServiceUrl: 'https://docs.4everland.org/storage/4ever-pin/pinning-services-api'
   }

--- a/src/explore/ExploreContainer.js
+++ b/src/explore/ExploreContainer.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { ExplorePage } from 'ipld-explorer-components/pages'
 import withTour from '../components/tour/withTour.js'
@@ -7,15 +7,32 @@ const ExploreContainer = ({
   toursEnabled,
   handleJoyrideCallback,
   availableGatewayUrl,
-  publicGateway
+  publicGateway,
+  publicSubdomainGateway,
+  explorerNeedsReload
 }) => {
+  // The explorer's Helia node reads the gateway config (kuboGateway) only when
+  // it boots, so a local gateway change made elsewhere cannot take effect in
+  // place. Reload lazily, only when the user actually opens Explore. The flag
+  // lives in non-persisted redux state, so the reload itself clears it.
+  useEffect(() => {
+    if (explorerNeedsReload) {
+      window.location.reload()
+    }
+  }, [explorerNeedsReload])
+
+  // "View on Public Gateway" appears only when the user configured a public
+  // gateway; prefer the subdomain one. null (not '') hides the link, since
+  // ExplorePage only falls back to its dweb.link default for undefined.
+  const publicGatewayUrl = publicSubdomainGateway || publicGateway || null
+
   return (
     <div className="e2e-explorePage">
       <ExplorePage
         runTour={toursEnabled}
         joyrideCallback={handleJoyrideCallback}
         gatewayUrl={availableGatewayUrl}
-        publicGateway={publicGateway}
+        publicGatewayUrl={publicGatewayUrl}
       />
     </div>
   )
@@ -25,5 +42,7 @@ export default connect(
   'selectToursEnabled',
   'selectAvailableGatewayUrl',
   'selectPublicGateway',
+  'selectPublicSubdomainGateway',
+  'selectExplorerNeedsReload',
   withTour(ExploreContainer)
 )

--- a/src/files/explore-form/files-explore-form.tsx
+++ b/src/files/explore-form/files-explore-form.tsx
@@ -118,7 +118,7 @@ const FilesExploreForm: React.FC<FilesExploreFormProps> = ({ onBrowse: onBrowseP
         <div className='flex'>
           <div className='flex-auto'>
             <div className='relative'>
-              <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='QmHash/bafyHash' aria-describedby='ipfs-path-desc' onChange={onChange} onKeyDown={onKeyDown} value={path} />
+              <input id='ipfs-path' className={`input-reset bn pa2 mb2 db w-100 f6 br-0 placeholder-light ${inputClass}`} style={{ borderRadius: '3px 0 0 3px' }} type='text' placeholder='cid, ipfs://cid, or /ipfs/cid' aria-describedby='ipfs-path-desc' onChange={onChange} onKeyDown={onKeyDown} value={path} />
               <small id='ipfs-path-desc' className='o-0 absolute f6 black-60 db mb2'>Paste in a CID or IPFS path</small>
             </div>
           </div>

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -4,7 +4,7 @@ import { connect } from 'redux-bundler-react'
 import { isBinary } from 'istextorbinary'
 import { Trans, withTranslation } from 'react-i18next'
 import typeFromExt from '../type-from-ext/index.js'
-import { safeSubresourceGwUrl } from '../../lib/files.js'
+import { toLoopbackIpUrl, getLocalContentLink } from '../../lib/share-link.js'
 import ComponentLoader from '../../loader/ComponentLoader.js'
 import './FilePreview.css'
 import { CID } from 'multiformats/cid'
@@ -54,7 +54,7 @@ const Drag = ({ name, size, cid, path, children }) => {
 }
 
 const Preview = (props) => {
-  const { t, name, cid, size, availableGatewayUrl, publicGateway, read, onDownload, onClose } = props
+  const { t, name, cid, size, availableGatewayUrl, localGatewayUrl, publicGateway, shareLinkType, read, onDownload, onClose } = props
   const [content, setContent] = useState(null)
   const [hasMoreContent, setHasMoreContent] = useState(false)
   const [buffer, setBuffer] = useState(null)
@@ -87,8 +87,27 @@ const Preview = (props) => {
   }, // eslint-disable-next-line react-hooks/exhaustive-deps
   [])
 
-  const src = `${availableGatewayUrl}/ipfs/${cid}?filename=${encodeURIComponent(name)}`
+  const filenameQuery = `?filename=${encodeURIComponent(name)}`
+  // Embedded subresources (img/video/audio/object) load from the available
+  // gateway in its IP form; see toLoopbackIpUrl.
+  const src = toLoopbackIpUrl(`${availableGatewayUrl}/ipfs/${cid}${filenameQuery}`)
   const className = 'mw-100 mt3 bg-snow-muted pa2 br2 border-box'
+
+  // Links that open the file in a new tab. The local one honors the Share Link
+  // type from Settings, giving content its own origin when the user chose the
+  // local subdomain gateway; either link is '' when its gateway is not
+  // configured.
+  const cidObj = CID.asCID(cid) ?? CID.parse(String(cid))
+  const localUrl = getLocalContentLink({
+    shareLinkType,
+    namespace: 'ipfs',
+    pathId: cidObj.toString(),
+    subdomainLabel: cidObj.toV1().toString(),
+    filename: filenameQuery,
+    localGatewayUrl
+  })
+  const publicUrl = publicGateway ? `${publicGateway}/ipfs/${cid}${filenameQuery}` : ''
+  const openUrl = localUrl || publicUrl
 
   // Close button header
   const closeButtonHeader = onClose != null && (
@@ -109,6 +128,38 @@ const Preview = (props) => {
     </div>
   )
 
+  const openLinks = localUrl && publicUrl
+    ? <Trans i18nKey='openWithLocalAndPublicGateway' t={t}>
+      Try opening it instead with your <a href={localUrl} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a> or <a href={publicUrl} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
+    </Trans>
+    : localUrl
+      ? <Trans i18nKey='openWithLocalGateway' t={t}>
+        Try opening it instead with your <a href={localUrl} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a>.
+      </Trans>
+      : publicUrl
+        ? <Trans i18nKey='openWithPublicGateway' t={t}>
+          Try opening it instead with your <a href={publicUrl} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
+        </Trans>
+        : null
+
+  const cantPreview = (
+    <div className='mt4'>
+      <p className='b'>{t('cantBePreviewed')} <span role='img' aria-label='sad'>😢</span></p>
+      { openLinks && <p>{openLinks}</p> }
+    </div>
+  )
+
+  // Embedded previews need a gateway to load from; without one, offer the
+  // open-elsewhere links instead of a broken embed.
+  if (['audio', 'video', 'pdf', 'image'].includes(type) && !availableGatewayUrl) {
+    return (
+      <div>
+        {closeButtonHeader}
+        {cantPreview}
+      </div>
+    )
+  }
+
   switch (type) {
     case 'audio':
       return (
@@ -117,7 +168,7 @@ const Preview = (props) => {
           <Drag {...props}>
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
             <audio width='100%' controls>
-              <source src={safeSubresourceGwUrl(src)} />
+              <source src={src} />
             </audio>
           </Drag>
         </div>
@@ -127,9 +178,9 @@ const Preview = (props) => {
         <div>
           {closeButtonHeader}
           <Drag {...props}>
-            <object className="FilePreviewPDF w-100" data={safeSubresourceGwUrl(src)} type='application/pdf'>
+            <object className="FilePreviewPDF w-100" data={src} type='application/pdf'>
               {t('noPDFSupport')}
-              <a href={src} download target='_blank' rel='noopener noreferrer' className='underline-hover navy-muted'>{t('downloadPDF')}</a>
+              { openUrl && <a href={openUrl} download target='_blank' rel='noopener noreferrer' className='underline-hover navy-muted'>{t('downloadPDF')}</a> }
             </object>
           </Drag>
         </div>
@@ -141,7 +192,7 @@ const Preview = (props) => {
           <Drag {...props}>
             {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
             <video controls className={className}>
-              <source src={safeSubresourceGwUrl(src)} />
+              <source src={src} />
             </video>
           </Drag>
         </div>
@@ -151,33 +202,11 @@ const Preview = (props) => {
         <div>
           {closeButtonHeader}
           <Drag {...props}>
-            <img className={className} alt={name} src={safeSubresourceGwUrl(src)} />
+            <img className={className} alt={name} src={src} />
           </Drag>
         </div>
       )
     default: {
-      const srcPublic = `${publicGateway}/ipfs/${cid}?filename=${encodeURIComponent(name)}`
-
-      const cantPreview = (
-        <div className='mt4'>
-          <p className='b'>{t('cantBePreviewed')} <span role='img' aria-label='sad'>😢</span></p>
-          <p>
-            { !publicGateway
-              ? <Trans i18nKey='openWithLocalGateway' t={t}>
-            Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a>.
-              </Trans>
-              : availableGatewayUrl === publicGateway
-                ? <Trans i18nKey='openWithPublicGateway' t={t}>
-            Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
-                </Trans>
-                : <Trans i18nKey='openWithLocalAndPublicGateway' t={t}>
-          Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a> or <a href={srcPublic} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
-                </Trans>
-            }
-          </p>
-        </div>
-      )
-
       if (content === null) {
         return (
           <div>
@@ -240,6 +269,8 @@ Preview.propTypes = {
 
 export default connect(
   'selectAvailableGatewayUrl',
+  'selectLocalGatewayUrl',
   'selectPublicGateway',
+  'selectShareLinkType',
   withTranslation('files')(Preview)
 )

--- a/src/files/file-preview/FilePreview.js
+++ b/src/files/file-preview/FilePreview.js
@@ -4,6 +4,7 @@ import { connect } from 'redux-bundler-react'
 import { isBinary } from 'istextorbinary'
 import { Trans, withTranslation } from 'react-i18next'
 import typeFromExt from '../type-from-ext/index.js'
+import { safeSubresourceGwUrl } from '../../lib/files.js'
 import ComponentLoader from '../../loader/ComponentLoader.js'
 import './FilePreview.css'
 import { CID } from 'multiformats/cid'
@@ -161,13 +162,17 @@ const Preview = (props) => {
         <div className='mt4'>
           <p className='b'>{t('cantBePreviewed')} <span role='img' aria-label='sad'>😢</span></p>
           <p>
-            { availableGatewayUrl === publicGateway
-              ? <Trans i18nKey='openWithPublicGateway' t={t}>
+            { !publicGateway
+              ? <Trans i18nKey='openWithLocalGateway' t={t}>
+            Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a>.
+              </Trans>
+              : availableGatewayUrl === publicGateway
+                ? <Trans i18nKey='openWithPublicGateway' t={t}>
             Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
-              </Trans>
-              : <Trans i18nKey='openWithLocalAndPublicGateway' t={t}>
+                </Trans>
+                : <Trans i18nKey='openWithLocalAndPublicGateway' t={t}>
           Try opening it instead with your <a href={src} download target='_blank' rel='noopener noreferrer' className='link blue'>local gateway</a> or <a href={srcPublic} download target='_blank' rel='noopener noreferrer' className='link blue'>public gateway</a>.
-              </Trans>
+                </Trans>
             }
           </p>
         </div>
@@ -238,19 +243,3 @@ export default connect(
   'selectPublicGateway',
   withTranslation('files')(Preview)
 )
-
-// Potential fix for mixed-content error when redirecting to localhost subdomain
-// from https://github.com/ipfs/ipfs-webui/issues/2246#issuecomment-2322192398
-// We do it here and not in src/bundles/config.js because we dont want IPLD
-// explorer to open links in path gateway, localhost is desired there.
-//
-// Context: localhost in Kubo is a subdomain gateway, so http://locahost:8080/ipfs/cid will
-// redirect to http://cid.ipfs.localhost:8080 – perhaps subdomains are not
-// interpreted as secure context correctly and that triggers forced upgrade to
-// https. switching to IP should help.
-function safeSubresourceGwUrl (url) {
-  if (url.startsWith('http://localhost:')) {
-    return url.replace('http://localhost:', 'http://127.0.0.1:')
-  }
-  return url
-}

--- a/src/files/file-preview/file-thumbnail.tsx
+++ b/src/files/file-preview/file-thumbnail.tsx
@@ -2,7 +2,7 @@ import { CID } from 'multiformats/cid'
 import React, { useState, useEffect, useCallback, type FC } from 'react'
 import { connect } from 'redux-bundler-react'
 import typeFromExt from '../type-from-ext/index.js'
-import { safeSubresourceGwUrl } from '../../lib/files.js'
+import { toLoopbackIpUrl } from '../../lib/share-link.js'
 import './file-thumbnail.css'
 
 export interface FileThumbnailProps {
@@ -40,8 +40,10 @@ const FileThumbnail: FC<FileThumbnailPropsConnected> = ({ name, cid, availableGa
     return null
   }
 
-  if (type === 'image') {
-    const src = safeSubresourceGwUrl(`${availableGatewayUrl}/ipfs/${cid}?filename=${encodeURIComponent(name)}`)
+  // An image thumbnail loads from the gateway; without one there is nothing to
+  // point the img at, so fall through to the text preview (or nothing).
+  if (type === 'image' && availableGatewayUrl) {
+    const src = toLoopbackIpUrl(`${availableGatewayUrl}/ipfs/${cid}?filename=${encodeURIComponent(name)}`)
     return (
       <div className={`file-thumbnail ${!imageLoaded ? 'is-loading' : ''}`}>
         <div className="file-thumbnail-loading" />

--- a/src/files/file-preview/file-thumbnail.tsx
+++ b/src/files/file-preview/file-thumbnail.tsx
@@ -2,6 +2,7 @@ import { CID } from 'multiformats/cid'
 import React, { useState, useEffect, useCallback, type FC } from 'react'
 import { connect } from 'redux-bundler-react'
 import typeFromExt from '../type-from-ext/index.js'
+import { safeSubresourceGwUrl } from '../../lib/files.js'
 import './file-thumbnail.css'
 
 export interface FileThumbnailProps {
@@ -40,7 +41,7 @@ const FileThumbnail: FC<FileThumbnailPropsConnected> = ({ name, cid, availableGa
   }
 
   if (type === 'image') {
-    const src = `${availableGatewayUrl}/ipfs/${cid}?filename=${encodeURIComponent(name)}`
+    const src = safeSubresourceGwUrl(`${availableGatewayUrl}/ipfs/${cid}?filename=${encodeURIComponent(name)}`)
     return (
       <div className={`file-thumbnail ${!imageLoaded ? 'is-loading' : ''}`}>
         <div className="file-thumbnail-loading" />

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -64,6 +64,8 @@ class Modals extends React.Component {
       files: []
     },
     link: '',
+    localLink: '',
+    subdomainLocalLink: '',
     command: 'ipfs --help'
   }
 
@@ -132,10 +134,16 @@ class Modals extends React.Component {
       case SHARE: {
         this.setState({
           link: t('generating'),
+          localLink: '',
+          subdomainLocalLink: '',
           readyToShow: true
         })
 
-        onShareLink(files).then(link => this.setState({ link }))
+        onShareLink(files).then(result => this.setState({
+          link: result.link,
+          localLink: result.localLink,
+          subdomainLocalLink: result.subdomainLocalLink
+        }))
         break
       }
       case RENAME: {
@@ -245,7 +253,7 @@ class Modals extends React.Component {
 
   render () {
     const { show, t } = this.props
-    const { readyToShow, link, rename, command } = this.state
+    const { readyToShow, link, localLink, subdomainLocalLink, rename, command } = this.state
     return (
       <div>
         <Overlay show={show === NEW_FOLDER && readyToShow} onLeave={this.leave}>
@@ -259,6 +267,8 @@ class Modals extends React.Component {
           <ShareModal
             className='outline-0'
             link={link}
+            localLink={localLink}
+            subdomainLocalLink={subdomainLocalLink}
             onLeave={this.leave} />
         </Overlay>
 

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -139,11 +139,16 @@ class Modals extends React.Component {
           readyToShow: true
         })
 
-        onShareLink(files).then(result => this.setState({
-          link: result.link,
-          localLink: result.localLink,
-          subdomainLocalLink: result.subdomainLocalLink
-        }))
+        onShareLink(files)
+          .then(result => this.setState({
+            link: result.link,
+            localLink: result.localLink,
+            subdomainLocalLink: result.subdomainLocalLink
+          }))
+          .catch(err => {
+            console.error('Failed to generate share link:', err)
+            this.setState({ link: t('shareModal.linkError') })
+          })
         break
       }
       case RENAME: {

--- a/src/files/modals/Modals.js
+++ b/src/files/modals/Modals.js
@@ -64,6 +64,7 @@ class Modals extends React.Component {
       files: []
     },
     link: '',
+    shareLinkType: '',
     localLink: '',
     subdomainLocalLink: '',
     command: 'ipfs --help'
@@ -134,6 +135,7 @@ class Modals extends React.Component {
       case SHARE: {
         this.setState({
           link: t('generating'),
+          shareLinkType: '',
           localLink: '',
           subdomainLocalLink: '',
           readyToShow: true
@@ -142,6 +144,7 @@ class Modals extends React.Component {
         onShareLink(files)
           .then(result => this.setState({
             link: result.link,
+            shareLinkType: result.type,
             localLink: result.localLink,
             subdomainLocalLink: result.subdomainLocalLink
           }))
@@ -258,7 +261,7 @@ class Modals extends React.Component {
 
   render () {
     const { show, t } = this.props
-    const { readyToShow, link, localLink, subdomainLocalLink, rename, command } = this.state
+    const { readyToShow, link, shareLinkType, localLink, subdomainLocalLink, rename, command } = this.state
     return (
       <div>
         <Overlay show={show === NEW_FOLDER && readyToShow} onLeave={this.leave}>
@@ -272,6 +275,7 @@ class Modals extends React.Component {
           <ShareModal
             className='outline-0'
             link={link}
+            type={shareLinkType}
             localLink={localLink}
             subdomainLocalLink={subdomainLocalLink}
             onLeave={this.leave} />

--- a/src/files/modals/publish-modal/PublishModal.js
+++ b/src/files/modals/publish-modal/PublishModal.js
@@ -13,7 +13,7 @@ import GlyphCopy from '../../../icons/GlyphCopy.js'
 import GlyphTick from '../../../icons/GlyphTick.js'
 import './PublishModal.css'
 
-export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, effectiveShareLinkType, gatewayUrl, publicGateway, publicSubdomainGateway, className, doFetchIpnsKeys, doUpdateExpectedPublishTime, expectedPublishTime, ...props }) => {
+export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, effectiveShareLinkType, localGatewayUrl, publicGateway, publicSubdomainGateway, className, doFetchIpnsKeys, doUpdateExpectedPublishTime, expectedPublishTime, ...props }) => {
   const [disabled, setDisabled] = useState(true)
   const [error, setError] = useState(null)
   const [selectedKey, setSelectedKey] = useState({ name: '', id: '' })
@@ -48,21 +48,19 @@ export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, eff
       setStart(startTs)
 
       await onSubmit(selectedKey.name)
-      // Match the Share Link type chosen in Settings, falling back to a native
-      // ipns:// URI when the selected type cannot be built (e.g. no gateway).
-      // The name is normalized to a base36 libp2p-key so subdomain and native
-      // links are valid.
+      // Match the Share Link type chosen in Settings; the effective type
+      // guarantees buildShareLink returns a link. The name is normalized to a
+      // base36 libp2p-key so subdomain and native links are valid.
       const ipnsName = toIpnsBase36(selectedKey.id)
-      const ipnsLink = buildShareLink({
+      setLink(buildShareLink({
         type: effectiveShareLinkType,
         namespace: 'ipns',
         pathId: ipnsName,
         subdomainLabel: ipnsName,
-        localGatewayUrl: gatewayUrl,
+        localGatewayUrl,
         publicGateway,
         publicSubdomainGateway
-      }) || `ipns://${ipnsName}`
-      setLink(ipnsLink)
+      }))
 
       // Update the expected time with the new timing.
       const endTs = new Date().getTime()
@@ -174,7 +172,7 @@ PublishModal.defaultProps = {
 export default connect(
   'selectIpnsKeys',
   'selectExpectedPublishTime',
-  'selectGatewayUrl',
+  'selectLocalGatewayUrl',
   'selectPublicGateway',
   'selectPublicSubdomainGateway',
   'selectEffectiveShareLinkType',

--- a/src/files/modals/publish-modal/PublishModal.js
+++ b/src/files/modals/publish-modal/PublishModal.js
@@ -7,12 +7,13 @@ import { Modal, ModalActions, ModalBody } from '../../../components/modal/modal'
 import Icon from '../../../icons/StrokeSpeaker.js'
 import { connect } from 'redux-bundler-react'
 import Radio from '../../../components/radio/radio.js'
+import { buildShareLink, toIpnsBase36 } from '../../../lib/share-link.js'
 import ProgressBar from '../../../components/progress-bar/ProgressBar.js'
 import GlyphCopy from '../../../icons/GlyphCopy.js'
 import GlyphTick from '../../../icons/GlyphTick.js'
 import './PublishModal.css'
 
-export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, publicGateway, className, doFetchIpnsKeys, doUpdateExpectedPublishTime, expectedPublishTime, ...props }) => {
+export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, effectiveShareLinkType, gatewayUrl, publicGateway, publicSubdomainGateway, className, doFetchIpnsKeys, doUpdateExpectedPublishTime, expectedPublishTime, ...props }) => {
   const [disabled, setDisabled] = useState(true)
   const [error, setError] = useState(null)
   const [selectedKey, setSelectedKey] = useState({ name: '', id: '' })
@@ -47,7 +48,21 @@ export const PublishModal = ({ t, tReady, onLeave, onSubmit, file, ipnsKeys, pub
       setStart(startTs)
 
       await onSubmit(selectedKey.name)
-      setLink(`${publicGateway}/ipns/${selectedKey.id}`)
+      // Match the Share Link type chosen in Settings, falling back to a native
+      // ipns:// URI when the selected type cannot be built (e.g. no gateway).
+      // The name is normalized to a base36 libp2p-key so subdomain and native
+      // links are valid.
+      const ipnsName = toIpnsBase36(selectedKey.id)
+      const ipnsLink = buildShareLink({
+        type: effectiveShareLinkType,
+        namespace: 'ipns',
+        pathId: ipnsName,
+        subdomainLabel: ipnsName,
+        localGatewayUrl: gatewayUrl,
+        publicGateway,
+        publicSubdomainGateway
+      }) || `ipns://${ipnsName}`
+      setLink(ipnsLink)
 
       // Update the expected time with the new timing.
       const endTs = new Date().getTime()
@@ -159,7 +174,10 @@ PublishModal.defaultProps = {
 export default connect(
   'selectIpnsKeys',
   'selectExpectedPublishTime',
+  'selectGatewayUrl',
   'selectPublicGateway',
+  'selectPublicSubdomainGateway',
+  'selectEffectiveShareLinkType',
   'doFetchIpnsKeys',
   'doUpdateExpectedPublishTime',
   withTranslation('files')(PublishModal)

--- a/src/files/modals/publish-modal/PublishModal.stories.js
+++ b/src/files/modals/publish-modal/PublishModal.stories.js
@@ -48,7 +48,7 @@ export default {
     },
     ipnsKeys,
     effectiveShareLinkType: 'public-path',
-    gatewayUrl: 'http://127.0.0.1:8080',
+    localGatewayUrl: 'http://127.0.0.1:8080',
     publicGateway: 'https://ipfs.io',
     publicSubdomainGateway: 'https://dweb.link',
     className: 'ma3',

--- a/src/files/modals/publish-modal/PublishModal.stories.js
+++ b/src/files/modals/publish-modal/PublishModal.stories.js
@@ -47,7 +47,10 @@ export default {
       cid: 'QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC'
     },
     ipnsKeys,
-    publicGateway: 'gateway',
+    effectiveShareLinkType: 'public-path',
+    gatewayUrl: 'http://127.0.0.1:8080',
+    publicGateway: 'https://ipfs.io',
+    publicSubdomainGateway: 'https://dweb.link',
     className: 'ma3',
     doFetchIpnsKeys: () => ipnsKeys,
     doUpdateExpectedPublishTime: (time) => action(`Update expected publish time: ${time}`),

--- a/src/files/modals/share-modal/ShareModal.js
+++ b/src/files/modals/share-modal/ShareModal.js
@@ -1,48 +1,85 @@
-import React from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import QRCode from 'react-qr-code'
 import Button from '../../../components/button/button.tsx'
+import Checkbox from '../../../components/checkbox/Checkbox.js'
 import { withTranslation } from 'react-i18next'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { Modal, ModalActions, ModalBody } from '../../../components/modal/modal'
 
-const ShareModal = ({ t, tReady, onLeave, link, className, ...props }) => (
-  <Modal {...props} className={className} onCancel={onLeave} >
-    <ModalBody title={t('shareModal.title')}>
-      <p className='charcoal w-90 center'>{t('shareModal.description')}</p>
-      <div className='flex justify-center pb3'>
-        <QRCode
-          size={180}
-          value={link}
-        />
-      </div>
-      <div className='flex center w-90 pb2'>
-        <input
-          value={link}
-          readOnly
-          className={'input-reset flex-grow-1 charcoal-muted ba b--black-20 br1 pa2 mr2 focus-outline'}
-          type='text' />
-      </div>
-    </ModalBody>
+const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, className, ...props }) => {
+  const [useLocalLink, setUseLocalLink] = useState(false)
+  const [useSubdomains, setUseSubdomains] = useState(false)
 
-    <ModalActions>
-      <Button className='ma2 tc' bg='bg-gray' onClick={onLeave}>{t('app:actions.close')}</Button>
-      <CopyToClipboard text={link} onCopy={onLeave}>
-        <Button className='ma2 tc'>{t('app:actions.copy')}</Button>
-      </CopyToClipboard>
-    </ModalActions>
-  </Modal>
-)
+  let activeLink = link
+  if (useLocalLink && localLink) {
+    activeLink = useSubdomains && subdomainLocalLink ? subdomainLocalLink : localLink
+  }
+
+  return (
+    <Modal {...props} className={className} onCancel={onLeave} >
+      <ModalBody title={t('shareModal.title')}>
+        <p className='charcoal w-90 center'>
+          {useLocalLink ? t('shareModal.descriptionLocal') : t('shareModal.description')}
+        </p>
+        {!useLocalLink && (
+          <div className='flex justify-center pb3'>
+            <QRCode
+              size={180}
+              value={activeLink}
+            />
+          </div>
+        )}
+        <div className='flex center w-90 pb2'>
+          <input
+            value={activeLink}
+            readOnly
+            className={'input-reset flex-grow-1 charcoal-muted ba b--black-20 br1 pa2 mr2 focus-outline'}
+            type='text' />
+        </div>
+        {localLink && (
+          <div className='flex center w-90 pb2'>
+            <Checkbox
+              checked={useLocalLink}
+              onChange={setUseLocalLink}
+              label={t('shareModal.useLocalLink')}
+            />
+          </div>
+        )}
+        {useLocalLink && subdomainLocalLink && (
+          <div className='flex center w-90 pb2 ml3'>
+            <Checkbox
+              checked={useSubdomains}
+              onChange={setUseSubdomains}
+              label={t('shareModal.useSubdomains')}
+            />
+          </div>
+        )}
+      </ModalBody>
+
+      <ModalActions>
+        <Button className='ma2 tc' bg='bg-gray' onClick={onLeave}>{t('app:actions.close')}</Button>
+        <CopyToClipboard text={activeLink} onCopy={onLeave}>
+          <Button className='ma2 tc'>{t('app:actions.copy')}</Button>
+        </CopyToClipboard>
+      </ModalActions>
+    </Modal>
+  )
+}
 
 ShareModal.propTypes = {
   onLeave: PropTypes.func.isRequired,
   link: PropTypes.string,
+  localLink: PropTypes.string,
+  subdomainLocalLink: PropTypes.string,
   t: PropTypes.func.isRequired,
   tReady: PropTypes.bool.isRequired
 }
 
 ShareModal.defaultProps = {
-  className: ''
+  className: '',
+  localLink: '',
+  subdomainLocalLink: ''
 }
 
 export default withTranslation('files')(ShareModal)

--- a/src/files/modals/share-modal/ShareModal.js
+++ b/src/files/modals/share-modal/ShareModal.js
@@ -11,6 +11,16 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
   const [useLocalLink, setUseLocalLink] = useState(false)
   const [useSubdomains, setUseSubdomains] = useState(false)
 
+  // Turning off the local link hides the nested subdomain checkbox, so clear its
+  // choice too; otherwise re-enabling the local link would jump straight to the
+  // subdomain variant without the user opting back in.
+  const toggleLocalLink = (checked) => {
+    setUseLocalLink(checked)
+    if (!checked) {
+      setUseSubdomains(false)
+    }
+  }
+
   let activeLink = link
   if (useLocalLink && localLink) {
     activeLink = useSubdomains && subdomainLocalLink ? subdomainLocalLink : localLink
@@ -41,7 +51,7 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
           <div className='flex center w-90 pb2'>
             <Checkbox
               checked={useLocalLink}
-              onChange={setUseLocalLink}
+              onChange={toggleLocalLink}
               label={t('shareModal.useLocalLink')}
             />
           </div>

--- a/src/files/modals/share-modal/ShareModal.js
+++ b/src/files/modals/share-modal/ShareModal.js
@@ -3,11 +3,14 @@ import PropTypes from 'prop-types'
 import QRCode from 'react-qr-code'
 import Button from '../../../components/button/button.tsx'
 import Checkbox from '../../../components/checkbox/Checkbox.js'
-import { withTranslation } from 'react-i18next'
+import { withTranslation, Trans } from 'react-i18next'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 import { Modal, ModalActions, ModalBody } from '../../../components/modal/modal'
+import { SHARE_LINK_TYPE } from '../../../lib/share-link.js'
 
-const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, className, ...props }) => {
+const COMPANION_URL = 'https://docs.ipfs.tech/install/ipfs-companion/'
+
+const ShareModal = ({ t, tReady, onLeave, link, type, localLink, subdomainLocalLink, className, ...props }) => {
   const [useLocalLink, setUseLocalLink] = useState(false)
   const [useSubdomains, setUseSubdomains] = useState(false)
 
@@ -21,18 +24,39 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
     }
   }
 
+  const isLocalType = type === SHARE_LINK_TYPE.LOCAL_PATH || type === SHARE_LINK_TYPE.LOCAL_SUBDOMAIN
+  const isPublicType = type === SHARE_LINK_TYPE.PUBLIC_PATH || type === SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN
+
+  // The Settings choice already decides the link, so the local-link checkboxes
+  // only add value when that choice is native or public (otherwise redundant).
+  const offerLocalLink = !isLocalType && Boolean(localLink)
+  const showingLocalLink = isLocalType || (offerLocalLink && useLocalLink)
+
   let activeLink = link
-  if (useLocalLink && localLink) {
+  if (offerLocalLink && useLocalLink) {
     activeLink = useSubdomains && subdomainLocalLink ? subdomainLocalLink : localLink
+  }
+
+  // A QR code only helps when scanning the link on another device, which is the
+  // public-gateway case; native and same-machine links are not scanned.
+  const showQRCode = isPublicType && !(offerLocalLink && useLocalLink)
+
+  let description = t('shareModal.description')
+  if (showingLocalLink) {
+    description = t('shareModal.descriptionLocal')
+  } else if (type === SHARE_LINK_TYPE.NATIVE) {
+    description = (
+      <Trans i18nKey='shareModal.descriptionNative' t={t}>
+        This native IPFS address opens in apps and browsers that support IPFS, like the <a className='link blue' href={COMPANION_URL} target='_blank' rel='noopener noreferrer'>IPFS Companion</a> extension.
+      </Trans>
+    )
   }
 
   return (
     <Modal {...props} className={className} onCancel={onLeave} >
       <ModalBody title={t('shareModal.title')}>
-        <p className='charcoal w-90 center'>
-          {useLocalLink ? t('shareModal.descriptionLocal') : t('shareModal.description')}
-        </p>
-        {!useLocalLink && (
+        <p className='charcoal w-90 center'>{description}</p>
+        {showQRCode && (
           <div className='flex justify-center pb3'>
             <QRCode
               size={180}
@@ -47,7 +71,7 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
             className={'input-reset flex-grow-1 charcoal-muted ba b--black-20 br1 pa2 mr2 focus-outline'}
             type='text' />
         </div>
-        {localLink && (
+        {offerLocalLink && (
           <div className='flex center w-90 pb2'>
             <Checkbox
               checked={useLocalLink}
@@ -56,7 +80,7 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
             />
           </div>
         )}
-        {useLocalLink && subdomainLocalLink && (
+        {offerLocalLink && useLocalLink && subdomainLocalLink && (
           <div className='flex center w-90 pb2 ml3'>
             <Checkbox
               checked={useSubdomains}
@@ -80,6 +104,7 @@ const ShareModal = ({ t, tReady, onLeave, link, localLink, subdomainLocalLink, c
 ShareModal.propTypes = {
   onLeave: PropTypes.func.isRequired,
   link: PropTypes.string,
+  type: PropTypes.string,
   localLink: PropTypes.string,
   subdomainLocalLink: PropTypes.string,
   t: PropTypes.func.isRequired,
@@ -88,6 +113,7 @@ ShareModal.propTypes = {
 
 ShareModal.defaultProps = {
   className: '',
+  type: '',
   localLink: '',
   subdomainLocalLink: ''
 }

--- a/src/files/modals/share-modal/ShareModal.stories.js
+++ b/src/files/modals/share-modal/ShareModal.stories.js
@@ -19,6 +19,8 @@ export const Share = () => (
     <ShareModal
       onLeave={action('Leave')}
       link="https://ipfs.io/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
+      localLink="http://127.0.0.1:8080/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
+      subdomainLocalLink="http://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8080/"
     />
   </div>
 )

--- a/src/files/modals/share-modal/ShareModal.stories.js
+++ b/src/files/modals/share-modal/ShareModal.stories.js
@@ -19,7 +19,7 @@ export const Share = () => (
     <ShareModal
       onLeave={action('Leave')}
       link="https://ipfs.io/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
-      localLink="http://127.0.0.1:8080/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
+      localLink="http://localhost:8080/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
       subdomainLocalLink="http://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8080/"
     />
   </div>

--- a/src/files/modals/share-modal/ShareModal.stories.js
+++ b/src/files/modals/share-modal/ShareModal.stories.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { action } from '@storybook/addon-actions'
 import i18n from '../../../i18n-decorator.js'
 import ShareModal from './ShareModal.js'
+import { SHARE_LINK_TYPE } from '../../../lib/share-link.js'
 
 /**
  * @type {import('@storybook/react').Meta}
@@ -18,8 +19,9 @@ export const Share = () => (
   <div className="ma3">
     <ShareModal
       onLeave={action('Leave')}
-      link="https://ipfs.io/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
-      localLink="http://localhost:8080/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
+      type={SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN}
+      link="https://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.dweb.link"
+      localLink="http://127.0.0.1:8080/ipfs/QmQK3p7MmycDutWkWAzJ4hNN1YBKK9bLTDz9jTtkWf16wC"
       subdomainLocalLink="http://bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi.ipfs.localhost:8080/"
     />
   </div>

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -29,6 +29,27 @@ export function normalizeFiles (files) {
 }
 
 /**
+ * Fix for the mixed-content error when loading from a localhost gateway, see
+ * https://github.com/ipfs/ipfs-webui/issues/2246
+ *
+ * localhost in Kubo is a subdomain gateway, so http://localhost:8080/ipfs/cid
+ * redirects to http://cid.ipfs.localhost:8080. Some browsers do not treat that
+ * subdomain as a secure context and force-upgrade it to https, which breaks the
+ * load; switching to the IP avoids the redirect.
+ *
+ * Applied at each load site (file previews, thumbnails, downloads, CAR links)
+ * rather than globally in config.js.
+ *
+ * @param {string} url - a gateway URL, or a full gateway content URL
+ * @returns {string}
+ */
+export function safeSubresourceGwUrl (url) {
+  // Match http://localhost with any port (or none), but not https or a host
+  // like localhostx; the lookahead requires a port, path, or end of string.
+  return url.replace(/^http:\/\/localhost(?=[:/]|$)/, 'http://127.0.0.1')
+}
+
+/**
  * @param {string} type
  * @param {string} name
  * @param {CID} cid
@@ -78,6 +99,7 @@ export async function makeCIDFromFiles (files, ipfs) {
  * @returns {Promise<string>}
  */
 export async function getDownloadLink (files, gatewayUrl, ipfs) {
+  gatewayUrl = safeSubresourceGwUrl(gatewayUrl)
   if (files.length === 1) {
     return getDownloadURL(files[0].type, files[0].name, files[0].cid, gatewayUrl)
   }
@@ -87,107 +109,15 @@ export async function getDownloadLink (files, gatewayUrl, ipfs) {
 }
 
 /**
- * Build the `?filename=...` query that hints a gateway at a download name.
- * Only a single file gets one; directories and multi-file selections do not.
+ * Resolve the root CID for a Share Link: a single item keeps its own CID, while
+ * a multi-item selection is wrapped in an ephemeral MFS directory.
  *
  * @param {FileStat[]} files
- * @returns {string} the query string, or '' when no filename hint applies
+ * @param {IPFSService} ipfs
+ * @returns {Promise<CID>}
  */
-function getFilenameQuery (files) {
-  if (files.length === 1 && files[0].type === 'file') {
-    return `?filename=${encodeURIComponent(files[0].name)}`
-  }
-  return ''
-}
-
-// Loopback hosts, matched against a URL hostname (IPv6 keeps its brackets). They
-// all reach the same local node, so its links use canonical forms: the IP for
-// the path link (no DNS needed) and localhost for the subdomain link (subdomain
-// origins need a hostname). https://github.com/ipfs/ipfs-webui/issues/1490
-const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '[::]'])
-const LOOPBACK_IP = '127.0.0.1'
-const LOOPBACK_HOSTNAME = 'localhost'
-
-/**
- * Whether a URL hostname is a bare IP literal rather than a domain name.
- * Subdomain gateways serve one origin per CID under a parent domain, so they
- * cannot be built on an IP such as 192.168.1.5.
- *
- * @param {string} hostname - a URL hostname (IPv6 keeps its surrounding brackets)
- * @returns {boolean}
- */
-function isIpHostname (hostname) {
-  // IPv6 literals are bracketed in a URL hostname, e.g. [::1]
-  if (hostname.startsWith('[')) {
-    return true
-  }
-  // IPv4 dotted quad, e.g. 127.0.0.1
-  return /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)
-}
-
-/**
- * Generates a shareable link for the provided files using a subdomain gateway as default or a path gateway as fallback.
- *
- * @param {FileStat[]} files - An array of file objects with their respective CIDs and names.
- * @param {string} gatewayUrl - The URL of the default IPFS gateway.
- * @param {string} subdomainGatewayUrl - The URL of the subdomain gateway.
- * @param {IPFSService} ipfs - The IPFS service instance for interacting with the IPFS network.
- * @returns {Promise<{link: string, cid: CID}>} - A promise that resolves to an object containing the shareable link and root CID.
- */
-export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, ipfs) {
-  const cid = files.length === 1 ? files[0].cid : await makeCIDFromFiles(files, ipfs)
-  const filename = getFilenameQuery(files)
-  const url = new URL(subdomainGatewayUrl)
-
-  /**
-   * dweb.link (subdomain isolation) is listed first as the new default option.
-   * However, ipfs.io (path gateway fallback) is also listed for CIDs that cannot be represented in a 63-character DNS label.
-   * This allows users to customize both the subdomain and path gateway they use, with the subdomain gateway being used by default whenever possible.
-   */
-  const base32Cid = cid.toV1().toString()
-  const shareableLink = base32Cid.length < 64
-    ? `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
-    : `${gatewayUrl}/ipfs/${cid}${filename}`
-
-  return { link: shareableLink, cid }
-}
-
-/**
- * Build local gateway links for opening content in other apps on the same
- * machine, honoring the user's Local Gateway URL override.
- *
- * For a loopback gateway (localhost, 127.0.0.1, ...) the two links use canonical
- * forms: the path link uses 127.0.0.1 (no DNS needed) and the subdomain link
- * uses localhost (subdomain origins need a hostname). A real domain gateway
- * keeps its host for both. A non-loopback IP gets no subdomain link, and neither
- * does a CIDv1 too long for a 63-character DNS label; subdomainLocalLink is ''.
- *
- * @param {FileStat[]} files
- * @param {CID} cid - root CID, already resolved by getShareableLink
- * @param {string} gatewayUrl - the local gateway URL
- * @returns {{localLink: string, subdomainLocalLink: string}}
- */
-export function getLocalLinks (files, cid, gatewayUrl) {
-  const filename = getFilenameQuery(files)
-  const url = new URL(gatewayUrl)
-  const isLoopback = LOOPBACK_HOSTNAMES.has(url.hostname)
-  const port = url.port ? `:${url.port}` : ''
-
-  const localLink = isLoopback
-    ? `${url.protocol}//${LOOPBACK_IP}${port}/ipfs/${cid}${filename}`
-    : `${gatewayUrl}/ipfs/${cid}${filename}`
-
-  const base32Cid = cid.toV1().toString()
-  let subdomainLocalLink = ''
-  if (base32Cid.length < 64) {
-    if (isLoopback) {
-      subdomainLocalLink = `${url.protocol}//${base32Cid}.ipfs.${LOOPBACK_HOSTNAME}${port}${filename}`
-    } else if (!isIpHostname(url.hostname)) {
-      subdomainLocalLink = `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
-    }
-  }
-
-  return { localLink, subdomainLocalLink }
+export async function resolveShareCid (files, ipfs) {
+  return files.length === 1 ? files[0].cid : makeCIDFromFiles(files, ipfs)
 }
 
 /**
@@ -198,6 +128,7 @@ export function getLocalLinks (files, cid, gatewayUrl) {
  * @returns {Promise<string>}
  */
 export async function getCarLink (files, gatewayUrl, ipfs) {
+  gatewayUrl = safeSubresourceGwUrl(gatewayUrl)
   let cid, filename
 
   if (files.length === 1) {

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -1,4 +1,5 @@
 import filesize from 'filesize'
+import { toLoopbackIpUrl } from './share-link.js'
 /**
  * @typedef {import('kubo-rpc-client').KuboRPCClient} IPFSService
  * @typedef {import('../bundles/files/actions').FileStat} FileStat
@@ -26,27 +27,6 @@ export function normalizeFiles (files) {
   }
 
   return streams
-}
-
-/**
- * Fix for the mixed-content error when loading from a localhost gateway, see
- * https://github.com/ipfs/ipfs-webui/issues/2246
- *
- * localhost in Kubo is a subdomain gateway, so http://localhost:8080/ipfs/cid
- * redirects to http://cid.ipfs.localhost:8080. Some browsers do not treat that
- * subdomain as a secure context and force-upgrade it to https, which breaks the
- * load; switching to the IP avoids the redirect.
- *
- * Applied at each load site (file previews, thumbnails, downloads, CAR links)
- * rather than globally in config.js.
- *
- * @param {string} url - a gateway URL, or a full gateway content URL
- * @returns {string}
- */
-export function safeSubresourceGwUrl (url) {
-  // Match http://localhost with any port (or none), but not https or a host
-  // like localhostx; the lookahead requires a port, path, or end of string.
-  return url.replace(/^http:\/\/localhost(?=[:/]|$)/, 'http://127.0.0.1')
 }
 
 /**
@@ -99,7 +79,7 @@ export async function makeCIDFromFiles (files, ipfs) {
  * @returns {Promise<string>}
  */
 export async function getDownloadLink (files, gatewayUrl, ipfs) {
-  gatewayUrl = safeSubresourceGwUrl(gatewayUrl)
+  gatewayUrl = toLoopbackIpUrl(gatewayUrl)
   if (files.length === 1) {
     return getDownloadURL(files[0].type, files[0].name, files[0].cid, gatewayUrl)
   }
@@ -128,7 +108,7 @@ export async function resolveShareCid (files, ipfs) {
  * @returns {Promise<string>}
  */
 export async function getCarLink (files, gatewayUrl, ipfs) {
-  gatewayUrl = safeSubresourceGwUrl(gatewayUrl)
+  gatewayUrl = toLoopbackIpUrl(gatewayUrl)
   let cid, filename
 
   if (files.length === 1) {

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -87,6 +87,37 @@ export async function getDownloadLink (files, gatewayUrl, ipfs) {
 }
 
 /**
+ * Build the `?filename=...` query that hints a gateway at a download name.
+ * Only a single file gets one; directories and multi-file selections do not.
+ *
+ * @param {FileStat[]} files
+ * @returns {string} the query string, or '' when no filename hint applies
+ */
+function getFilenameQuery (files) {
+  if (files.length === 1 && files[0].type === 'file') {
+    return `?filename=${encodeURIComponent(files[0].name)}`
+  }
+  return ''
+}
+
+/**
+ * Whether a URL hostname is a bare IP literal rather than a domain name.
+ * Subdomain gateways serve one origin per CID under a parent domain, so they
+ * cannot be built on an IP such as 127.0.0.1 or [::1].
+ *
+ * @param {string} hostname - a URL hostname (IPv6 keeps its surrounding brackets)
+ * @returns {boolean}
+ */
+function isIpHostname (hostname) {
+  // IPv6 literals are bracketed in a URL hostname, e.g. [::1]
+  if (hostname.startsWith('[')) {
+    return true
+  }
+  // IPv4 dotted quad, e.g. 127.0.0.1
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)
+}
+
+/**
  * Generates a shareable link for the provided files using a subdomain gateway as default or a path gateway as fallback.
  *
  * @param {FileStat[]} files - An array of file objects with their respective CIDs and names.
@@ -96,18 +127,8 @@ export async function getDownloadLink (files, gatewayUrl, ipfs) {
  * @returns {Promise<{link: string, cid: CID}>} - A promise that resolves to an object containing the shareable link and root CID.
  */
 export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, ipfs) {
-  let cid
-  let filename
-
-  if (files.length === 1) {
-    cid = files[0].cid
-    if (files[0].type === 'file') {
-      filename = `?filename=${encodeURIComponent(files[0].name)}`
-    }
-  } else {
-    cid = await makeCIDFromFiles(files, ipfs)
-  }
-
+  const cid = files.length === 1 ? files[0].cid : await makeCIDFromFiles(files, ipfs)
+  const filename = getFilenameQuery(files)
   const url = new URL(subdomainGatewayUrl)
 
   /**
@@ -115,15 +136,40 @@ export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, 
    * However, ipfs.io (path gateway fallback) is also listed for CIDs that cannot be represented in a 63-character DNS label.
    * This allows users to customize both the subdomain and path gateway they use, with the subdomain gateway being used by default whenever possible.
    */
-  let shareableLink = ''
   const base32Cid = cid.toV1().toString()
-  if (base32Cid.length < 64) {
-    shareableLink = `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename || ''}`
-  } else {
-    shareableLink = `${gatewayUrl}/ipfs/${cid}${filename || ''}`
-  }
+  const shareableLink = base32Cid.length < 64
+    ? `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
+    : `${gatewayUrl}/ipfs/${cid}${filename}`
 
   return { link: shareableLink, cid }
+}
+
+/**
+ * Build local gateway links for opening content in other apps on the same
+ * machine. The path link works on any gateway. The subdomain link gives web
+ * apps an isolated origin and is set only when the gateway is reachable by a
+ * domain name (subdomain gateways do not work on bare IPs) and the CIDv1 fits
+ * in a 63-character DNS label. When it does not apply, subdomainLocalLink is ''.
+ *
+ * gatewayUrl honors the user's Local Gateway URL override, so both links point
+ * at whatever host, port and scheme the override (or Kubo config) specifies.
+ *
+ * @param {FileStat[]} files
+ * @param {CID} cid - root CID, already resolved by getShareableLink
+ * @param {string} gatewayUrl - the local gateway URL
+ * @returns {{localLink: string, subdomainLocalLink: string}}
+ */
+export function getLocalLinks (files, cid, gatewayUrl) {
+  const filename = getFilenameQuery(files)
+  const localLink = `${gatewayUrl}/ipfs/${cid}${filename}`
+
+  const url = new URL(gatewayUrl)
+  const base32Cid = cid.toV1().toString()
+  const subdomainLocalLink = !isIpHostname(url.hostname) && base32Cid.length < 64
+    ? `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
+    : ''
+
+  return { localLink, subdomainLocalLink }
 }
 
 /**

--- a/src/lib/files.js
+++ b/src/lib/files.js
@@ -100,10 +100,18 @@ function getFilenameQuery (files) {
   return ''
 }
 
+// Loopback hosts, matched against a URL hostname (IPv6 keeps its brackets). They
+// all reach the same local node, so its links use canonical forms: the IP for
+// the path link (no DNS needed) and localhost for the subdomain link (subdomain
+// origins need a hostname). https://github.com/ipfs/ipfs-webui/issues/1490
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '[::]'])
+const LOOPBACK_IP = '127.0.0.1'
+const LOOPBACK_HOSTNAME = 'localhost'
+
 /**
  * Whether a URL hostname is a bare IP literal rather than a domain name.
  * Subdomain gateways serve one origin per CID under a parent domain, so they
- * cannot be built on an IP such as 127.0.0.1 or [::1].
+ * cannot be built on an IP such as 192.168.1.5.
  *
  * @param {string} hostname - a URL hostname (IPv6 keeps its surrounding brackets)
  * @returns {boolean}
@@ -146,13 +154,13 @@ export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, 
 
 /**
  * Build local gateway links for opening content in other apps on the same
- * machine. The path link works on any gateway. The subdomain link gives web
- * apps an isolated origin and is set only when the gateway is reachable by a
- * domain name (subdomain gateways do not work on bare IPs) and the CIDv1 fits
- * in a 63-character DNS label. When it does not apply, subdomainLocalLink is ''.
+ * machine, honoring the user's Local Gateway URL override.
  *
- * gatewayUrl honors the user's Local Gateway URL override, so both links point
- * at whatever host, port and scheme the override (or Kubo config) specifies.
+ * For a loopback gateway (localhost, 127.0.0.1, ...) the two links use canonical
+ * forms: the path link uses 127.0.0.1 (no DNS needed) and the subdomain link
+ * uses localhost (subdomain origins need a hostname). A real domain gateway
+ * keeps its host for both. A non-loopback IP gets no subdomain link, and neither
+ * does a CIDv1 too long for a 63-character DNS label; subdomainLocalLink is ''.
  *
  * @param {FileStat[]} files
  * @param {CID} cid - root CID, already resolved by getShareableLink
@@ -161,13 +169,23 @@ export async function getShareableLink (files, gatewayUrl, subdomainGatewayUrl, 
  */
 export function getLocalLinks (files, cid, gatewayUrl) {
   const filename = getFilenameQuery(files)
-  const localLink = `${gatewayUrl}/ipfs/${cid}${filename}`
-
   const url = new URL(gatewayUrl)
+  const isLoopback = LOOPBACK_HOSTNAMES.has(url.hostname)
+  const port = url.port ? `:${url.port}` : ''
+
+  const localLink = isLoopback
+    ? `${url.protocol}//${LOOPBACK_IP}${port}/ipfs/${cid}${filename}`
+    : `${gatewayUrl}/ipfs/${cid}${filename}`
+
   const base32Cid = cid.toV1().toString()
-  const subdomainLocalLink = !isIpHostname(url.hostname) && base32Cid.length < 64
-    ? `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
-    : ''
+  let subdomainLocalLink = ''
+  if (base32Cid.length < 64) {
+    if (isLoopback) {
+      subdomainLocalLink = `${url.protocol}//${base32Cid}.ipfs.${LOOPBACK_HOSTNAME}${port}${filename}`
+    } else if (!isIpHostname(url.hostname)) {
+      subdomainLocalLink = `${url.protocol}//${base32Cid}.ipfs.${url.host}${filename}`
+    }
+  }
 
   return { localLink, subdomainLocalLink }
 }

--- a/src/lib/files.test.js
+++ b/src/lib/files.test.js
@@ -1,5 +1,5 @@
 /* global it, expect */
-import { normalizeFiles, getShareableLink } from './files.js'
+import { normalizeFiles, getShareableLink, getLocalLinks } from './files.js'
 import { DEFAULT_SUBDOMAIN_GATEWAY, DEFAULT_PATH_GATEWAY } from '../bundles/gateway.js'
 import { CID } from 'multiformats/cid'
 
@@ -283,4 +283,51 @@ it('should get a path gateway url', async () => {
   const { link: res, cid } = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
   expect(res).toBe(DEFAULT_PATH_GATEWAY + '/ipfs/' + veryLongCidv1)
   expect(cid).toBeDefined()
+})
+
+const SHORT_CID = CID.parse('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')
+const SHORT_CID_BASE32 = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
+
+it('getLocalLinks builds path and subdomain links for a domain gateway', () => {
+  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
+  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://localhost:8080')
+
+  expect(localLink).toBe(`http://localhost:8080/ipfs/${SHORT_CID}?filename=example.txt`)
+  expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+})
+
+it('getLocalLinks omits the subdomain link for an IP gateway', () => {
+  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
+
+  const ipv4 = getLocalLinks(files, SHORT_CID, 'http://127.0.0.1:8080')
+  expect(ipv4.localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}?filename=example.txt`)
+  expect(ipv4.subdomainLocalLink).toBe('')
+
+  const ipv6 = getLocalLinks(files, SHORT_CID, 'http://[::1]:8080')
+  expect(ipv6.subdomainLocalLink).toBe('')
+})
+
+it('getLocalLinks honors the user override host and scheme', () => {
+  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
+  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'https://gw.example.com')
+
+  expect(localLink).toBe(`https://gw.example.com/ipfs/${SHORT_CID}?filename=example.txt`)
+  expect(subdomainLocalLink).toBe(`https://${SHORT_CID_BASE32}.ipfs.gw.example.com?filename=example.txt`)
+})
+
+it('getLocalLinks omits the subdomain link when the CID exceeds a DNS label', () => {
+  const longCid = CID.parse('bagaaifcavabu6fzheerrmtxbbwv7jjhc3kaldmm7lbnvfopyrthcvod4m6ygpj3unrcggkzhvcwv5wnhc5ufkgzlsji7agnmofovc2g4a3ui7ja')
+  const files = [{ cid: longCid, name: 'example.txt', type: 'file' }]
+  const { localLink, subdomainLocalLink } = getLocalLinks(files, longCid, 'http://localhost:8080')
+
+  expect(localLink).toBe(`http://localhost:8080/ipfs/${longCid}?filename=example.txt`)
+  expect(subdomainLocalLink).toBe('')
+})
+
+it('getLocalLinks adds no filename query for a directory', () => {
+  const files = [{ cid: SHORT_CID, name: 'a-directory', type: 'directory' }]
+  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://localhost:8080')
+
+  expect(localLink).toBe(`http://localhost:8080/ipfs/${SHORT_CID}`)
+  expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080`)
 })

--- a/src/lib/files.test.js
+++ b/src/lib/files.test.js
@@ -1,6 +1,6 @@
 /* global it, expect */
 import { CID } from 'multiformats/cid'
-import { normalizeFiles, safeSubresourceGwUrl, getDownloadLink, getCarLink } from './files.js'
+import { normalizeFiles, getDownloadLink, getCarLink } from './files.js'
 
 function expectRightFormat (output) {
   expect(Array.isArray(output)).toBe(true)
@@ -249,21 +249,6 @@ it('drop multiple directories', async () => {
 
   expectRightFormat(output)
   expectRightOutput(output, expected)
-})
-
-it('safeSubresourceGwUrl rewrites http localhost to 127.0.0.1', () => {
-  expect(safeSubresourceGwUrl('http://localhost:8080/ipfs/bafy?filename=a.txt')).toBe('http://127.0.0.1:8080/ipfs/bafy?filename=a.txt')
-})
-
-it('safeSubresourceGwUrl rewrites http localhost on the default port', () => {
-  expect(safeSubresourceGwUrl('http://localhost/ipfs/bafy')).toBe('http://127.0.0.1/ipfs/bafy')
-})
-
-it('safeSubresourceGwUrl leaves other hosts and schemes unchanged', () => {
-  expect(safeSubresourceGwUrl('http://127.0.0.1:8080/ipfs/bafy')).toBe('http://127.0.0.1:8080/ipfs/bafy')
-  expect(safeSubresourceGwUrl('https://dweb.link/ipfs/bafy')).toBe('https://dweb.link/ipfs/bafy')
-  expect(safeSubresourceGwUrl('https://localhost:8080/ipfs/bafy')).toBe('https://localhost:8080/ipfs/bafy')
-  expect(safeSubresourceGwUrl('http://localhostx:8080/ipfs/bafy')).toBe('http://localhostx:8080/ipfs/bafy')
 })
 
 it('getDownloadLink and getCarLink route a localhost gateway through 127.0.0.1', async () => {

--- a/src/lib/files.test.js
+++ b/src/lib/files.test.js
@@ -288,26 +288,19 @@ it('should get a path gateway url', async () => {
 const SHORT_CID = CID.parse('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')
 const SHORT_CID_BASE32 = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
 
-it('getLocalLinks builds path and subdomain links for a domain gateway', () => {
-  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
-  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://localhost:8080')
+it('getLocalLinks gives loopback gateways an IP path link and a localhost subdomain link', () => {
+  // localhost, 127.0.0.1 and [::1] are the same local node: the path link uses
+  // the IP (no DNS) and the subdomain link uses localhost (origins need a name).
+  for (const gateway of ['http://localhost:8080', 'http://127.0.0.1:8080', 'http://[::1]:8080']) {
+    const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
+    const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, gateway)
 
-  expect(localLink).toBe(`http://localhost:8080/ipfs/${SHORT_CID}?filename=example.txt`)
-  expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+    expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}?filename=example.txt`)
+    expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+  }
 })
 
-it('getLocalLinks omits the subdomain link for an IP gateway', () => {
-  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
-
-  const ipv4 = getLocalLinks(files, SHORT_CID, 'http://127.0.0.1:8080')
-  expect(ipv4.localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}?filename=example.txt`)
-  expect(ipv4.subdomainLocalLink).toBe('')
-
-  const ipv6 = getLocalLinks(files, SHORT_CID, 'http://[::1]:8080')
-  expect(ipv6.subdomainLocalLink).toBe('')
-})
-
-it('getLocalLinks honors the user override host and scheme', () => {
+it('getLocalLinks leaves a non-loopback domain gateway unchanged', () => {
   const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
   const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'https://gw.example.com')
 
@@ -315,12 +308,20 @@ it('getLocalLinks honors the user override host and scheme', () => {
   expect(subdomainLocalLink).toBe(`https://${SHORT_CID_BASE32}.ipfs.gw.example.com?filename=example.txt`)
 })
 
+it('getLocalLinks omits the subdomain link for a non-loopback IP gateway', () => {
+  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
+  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://192.168.1.5:8080')
+
+  expect(localLink).toBe(`http://192.168.1.5:8080/ipfs/${SHORT_CID}?filename=example.txt`)
+  expect(subdomainLocalLink).toBe('')
+})
+
 it('getLocalLinks omits the subdomain link when the CID exceeds a DNS label', () => {
   const longCid = CID.parse('bagaaifcavabu6fzheerrmtxbbwv7jjhc3kaldmm7lbnvfopyrthcvod4m6ygpj3unrcggkzhvcwv5wnhc5ufkgzlsji7agnmofovc2g4a3ui7ja')
   const files = [{ cid: longCid, name: 'example.txt', type: 'file' }]
   const { localLink, subdomainLocalLink } = getLocalLinks(files, longCid, 'http://localhost:8080')
 
-  expect(localLink).toBe(`http://localhost:8080/ipfs/${longCid}?filename=example.txt`)
+  expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${longCid}?filename=example.txt`)
   expect(subdomainLocalLink).toBe('')
 })
 
@@ -328,6 +329,6 @@ it('getLocalLinks adds no filename query for a directory', () => {
   const files = [{ cid: SHORT_CID, name: 'a-directory', type: 'directory' }]
   const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://localhost:8080')
 
-  expect(localLink).toBe(`http://localhost:8080/ipfs/${SHORT_CID}`)
+  expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}`)
   expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080`)
 })

--- a/src/lib/files.test.js
+++ b/src/lib/files.test.js
@@ -1,7 +1,6 @@
 /* global it, expect */
-import { normalizeFiles, getShareableLink, getLocalLinks } from './files.js'
-import { DEFAULT_SUBDOMAIN_GATEWAY, DEFAULT_PATH_GATEWAY } from '../bundles/gateway.js'
 import { CID } from 'multiformats/cid'
+import { normalizeFiles, safeSubresourceGwUrl, getDownloadLink, getCarLink } from './files.js'
 
 function expectRightFormat (output) {
   expect(Array.isArray(output)).toBe(true)
@@ -252,83 +251,26 @@ it('drop multiple directories', async () => {
   expectRightOutput(output, expected)
 })
 
-it('should get a subdomain gateway url', async () => {
-  const ipfs = {}
-  const myCID = CID.parse('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')
-  const file = {
-    cid: myCID,
-    name: 'example.txt'
-  }
-  const files = [file]
-
-  const url = new URL(DEFAULT_SUBDOMAIN_GATEWAY)
-  const { link: shareableLink, cid } = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
-  const base32Cid = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
-  const rightShareableLink = `${url.protocol}//${base32Cid}.ipfs.${url.host}`
-  expect(shareableLink).toBe(rightShareableLink)
-  expect(cid).toBeDefined()
+it('safeSubresourceGwUrl rewrites http localhost to 127.0.0.1', () => {
+  expect(safeSubresourceGwUrl('http://localhost:8080/ipfs/bafy?filename=a.txt')).toBe('http://127.0.0.1:8080/ipfs/bafy?filename=a.txt')
 })
 
-it('should get a path gateway url', async () => {
-  const ipfs = {}
-  // very long CID v1 (using sha3-512)
-  const veryLongCidv1 = 'bagaaifcavabu6fzheerrmtxbbwv7jjhc3kaldmm7lbnvfopyrthcvod4m6ygpj3unrcggkzhvcwv5wnhc5ufkgzlsji7agnmofovc2g4a3ui7ja'
-  const myCID = CID.parse(veryLongCidv1)
-  const file = {
-    cid: myCID,
-    name: 'example.txt'
-  }
-  const files = [file]
-
-  const { link: res, cid } = await getShareableLink(files, DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, ipfs)
-  expect(res).toBe(DEFAULT_PATH_GATEWAY + '/ipfs/' + veryLongCidv1)
-  expect(cid).toBeDefined()
+it('safeSubresourceGwUrl rewrites http localhost on the default port', () => {
+  expect(safeSubresourceGwUrl('http://localhost/ipfs/bafy')).toBe('http://127.0.0.1/ipfs/bafy')
 })
 
-const SHORT_CID = CID.parse('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')
-const SHORT_CID_BASE32 = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
-
-it('getLocalLinks gives loopback gateways an IP path link and a localhost subdomain link', () => {
-  // localhost, 127.0.0.1 and [::1] are the same local node: the path link uses
-  // the IP (no DNS) and the subdomain link uses localhost (origins need a name).
-  for (const gateway of ['http://localhost:8080', 'http://127.0.0.1:8080', 'http://[::1]:8080']) {
-    const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
-    const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, gateway)
-
-    expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}?filename=example.txt`)
-    expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
-  }
+it('safeSubresourceGwUrl leaves other hosts and schemes unchanged', () => {
+  expect(safeSubresourceGwUrl('http://127.0.0.1:8080/ipfs/bafy')).toBe('http://127.0.0.1:8080/ipfs/bafy')
+  expect(safeSubresourceGwUrl('https://dweb.link/ipfs/bafy')).toBe('https://dweb.link/ipfs/bafy')
+  expect(safeSubresourceGwUrl('https://localhost:8080/ipfs/bafy')).toBe('https://localhost:8080/ipfs/bafy')
+  expect(safeSubresourceGwUrl('http://localhostx:8080/ipfs/bafy')).toBe('http://localhostx:8080/ipfs/bafy')
 })
 
-it('getLocalLinks leaves a non-loopback domain gateway unchanged', () => {
-  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
-  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'https://gw.example.com')
-
-  expect(localLink).toBe(`https://gw.example.com/ipfs/${SHORT_CID}?filename=example.txt`)
-  expect(subdomainLocalLink).toBe(`https://${SHORT_CID_BASE32}.ipfs.gw.example.com?filename=example.txt`)
-})
-
-it('getLocalLinks omits the subdomain link for a non-loopback IP gateway', () => {
-  const files = [{ cid: SHORT_CID, name: 'example.txt', type: 'file' }]
-  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://192.168.1.5:8080')
-
-  expect(localLink).toBe(`http://192.168.1.5:8080/ipfs/${SHORT_CID}?filename=example.txt`)
-  expect(subdomainLocalLink).toBe('')
-})
-
-it('getLocalLinks omits the subdomain link when the CID exceeds a DNS label', () => {
-  const longCid = CID.parse('bagaaifcavabu6fzheerrmtxbbwv7jjhc3kaldmm7lbnvfopyrthcvod4m6ygpj3unrcggkzhvcwv5wnhc5ufkgzlsji7agnmofovc2g4a3ui7ja')
-  const files = [{ cid: longCid, name: 'example.txt', type: 'file' }]
-  const { localLink, subdomainLocalLink } = getLocalLinks(files, longCid, 'http://localhost:8080')
-
-  expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${longCid}?filename=example.txt`)
-  expect(subdomainLocalLink).toBe('')
-})
-
-it('getLocalLinks adds no filename query for a directory', () => {
-  const files = [{ cid: SHORT_CID, name: 'a-directory', type: 'directory' }]
-  const { localLink, subdomainLocalLink } = getLocalLinks(files, SHORT_CID, 'http://localhost:8080')
-
-  expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${SHORT_CID}`)
-  expect(subdomainLocalLink).toBe(`http://${SHORT_CID_BASE32}.ipfs.localhost:8080`)
+it('getDownloadLink and getCarLink route a localhost gateway through 127.0.0.1', async () => {
+  const cid = CID.parse('bafkqac3imvwgy3zao5xxe3de')
+  const files = [{ type: 'file', name: 'a.txt', cid }]
+  expect(await getDownloadLink(files, 'http://localhost:8080', null)).toMatch(/^http:\/\/127\.0\.0\.1:8080\/ipfs\//)
+  expect(await getCarLink(files, 'http://localhost:8080', null)).toMatch(/^http:\/\/127\.0\.0\.1:8080\/ipfs\//)
+  // a non-localhost gateway is passed through untouched
+  expect(await getDownloadLink(files, 'https://dweb.link', null)).toMatch(/^https:\/\/dweb\.link\/ipfs\//)
 })

--- a/src/lib/share-link.js
+++ b/src/lib/share-link.js
@@ -33,11 +33,63 @@ export const DEFAULT_SHARE_LINK_TYPE = SHARE_LINK_TYPE.NATIVE
 const DNS_LABEL_MAX = 63
 
 // Loopback hosts reach the same local node, so local links use canonical forms:
-// the IP for path links (no DNS needed) and localhost for subdomain links
-// (subdomain origins need a hostname). https://github.com/ipfs/ipfs-webui/issues/1490
+// the IP for path links and subresources (no DNS, and no localhost subdomain
+// redirect that some browsers force-upgrade to https, see
+// https://github.com/ipfs/ipfs-webui/issues/2246) and localhost for subdomain
+// links (subdomain origins need a hostname).
+// https://github.com/ipfs/ipfs-webui/issues/1490
 const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '[::]'])
-const LOOPBACK_IP = '127.0.0.1'
+const LOOPBACK_IPV4 = '127.0.0.1'
+const LOOPBACK_IPV6 = '[::1]'
 const LOOPBACK_HOSTNAME = 'localhost'
+
+/**
+ * The canonical loopback IP for a loopback hostname, keeping the address
+ * family of the input ([::] and [::1] stay IPv6).
+ *
+ * @param {string} hostname - a member of LOOPBACK_HOSTNAMES
+ * @returns {string}
+ */
+function loopbackIp (hostname) {
+  return hostname.startsWith('[') ? LOOPBACK_IPV6 : LOOPBACK_IPV4
+}
+
+/**
+ * Whether a loopback host in this URL may be rewritten to another loopback
+ * form. Only http qualifies: an https certificate covers the exact hostname,
+ * so swapping localhost and 127.0.0.1 would break TLS validation.
+ *
+ * @param {URL} url
+ * @returns {boolean}
+ */
+function isRewritableLoopback (url) {
+  return url.protocol === 'http:' && LOOPBACK_HOSTNAMES.has(url.hostname)
+}
+
+/**
+ * Rewrite a loopback host in an http URL to its canonical IP form (127.0.0.1
+ * or [::1]). This is the form for subresources (img/video/object embeds) and
+ * path links: it avoids Kubo's localhost subdomain redirect, which some
+ * browsers treat as an insecure context and force-upgrade to https, breaking
+ * the load (https://github.com/ipfs/ipfs-webui/issues/2246). Accepts a full
+ * content URL or a bare gateway root; https, non-loopback, and unparseable
+ * values pass through unchanged.
+ *
+ * @param {string} url
+ * @returns {string}
+ */
+export function toLoopbackIpUrl (url) {
+  let parsed
+  try {
+    parsed = new URL(url)
+  } catch {
+    return url
+  }
+  if (!isRewritableLoopback(parsed)) return url
+  // Surgical host swap: URL serialization would append a trailing slash to a
+  // bare gateway root, breaking callers that concatenate paths onto it.
+  return url.replace(parsed.hostname, loopbackIp(parsed.hostname))
+}
 
 /**
  * Build the `?filename=...` query that hints a gateway at a download name.
@@ -77,16 +129,16 @@ function isIpHostname (hostname) {
  * @param {string} namespace - 'ipfs' or 'ipns'
  * @param {string} id - CID string or IPNS name
  * @param {string} filename - `?filename=...` query, or ''
- * @param {{loopback?: boolean}} [opts] - normalize a loopback host to 127.0.0.1
+ * @param {{loopback?: boolean}} [opts] - normalize an http loopback host to its IP form
  * @returns {string} the link, or '' when gatewayUrl is empty
  */
 function pathLink (gatewayUrl, namespace, id, filename, opts = {}) {
   if (!gatewayUrl) return ''
   const url = new URL(gatewayUrl)
   let host = url.host
-  if (opts.loopback && LOOPBACK_HOSTNAMES.has(url.hostname)) {
+  if (opts.loopback && isRewritableLoopback(url)) {
     const port = url.port ? `:${url.port}` : ''
-    host = `${LOOPBACK_IP}${port}`
+    host = `${loopbackIp(url.hostname)}${port}`
   }
   // Preserve any subpath the gateway is mounted under (e.g. a reverse proxy at
   // https://example.com/gw); '/' collapses to an empty base.
@@ -103,14 +155,14 @@ function pathLink (gatewayUrl, namespace, id, filename, opts = {}) {
  * @param {string} namespace - 'ipfs' or 'ipns'
  * @param {string} label - base32 CIDv1 or IPNS name to place in the DNS label
  * @param {string} filename - `?filename=...` query, or ''
- * @param {{loopback?: boolean}} [opts] - normalize a loopback host to localhost
+ * @param {{loopback?: boolean}} [opts] - normalize an http loopback host to localhost
  * @returns {string}
  */
 function subdomainLink (gatewayUrl, namespace, label, filename, opts = {}) {
   if (!gatewayUrl || !label || label.length > DNS_LABEL_MAX) return ''
   const url = new URL(gatewayUrl)
   let hostname = url.hostname
-  if (opts.loopback && LOOPBACK_HOSTNAMES.has(hostname)) hostname = LOOPBACK_HOSTNAME
+  if (opts.loopback && isRewritableLoopback(url)) hostname = LOOPBACK_HOSTNAME
   if (isIpHostname(hostname)) return ''
   const port = url.port ? `:${url.port}` : ''
   return `${url.protocol}//${label}.${namespace}.${hostname}${port}${filename}`
@@ -119,9 +171,12 @@ function subdomainLink (gatewayUrl, namespace, label, filename, opts = {}) {
 /**
  * Build a single content link of the requested type, for the `/ipfs` (Share
  * Link) or `/ipns` (Publish to IPNS) namespace. Public subdomain links fall
- * back to the public path gateway when the label is too long for DNS; local
- * subdomain links fall back to the local path link. Returns '' when the type
- * cannot be built (e.g. a public type with no public gateway configured).
+ * back to the public path gateway when the label is too long for DNS (and to a
+ * native URI when there is no path gateway either); local subdomain links fall
+ * back to the local path link. Returns '' only when the type's own gateway is
+ * missing (a local type with no localGatewayUrl, or public path with no
+ * publicGateway); resolveEffectiveShareLinkType maps those cases to NATIVE
+ * first, so share flows always get a usable link.
  *
  * @param {object} opts
  * @param {string} opts.type - a SHARE_LINK_TYPE value
@@ -151,11 +206,38 @@ export function buildShareLink ({ type, namespace, pathId, subdomainLabel, filen
     case SHARE_LINK_TYPE.PUBLIC_PATH:
       return pathLink(publicGateway || '', namespace, pathId, filename)
     case SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN:
+      // A label too long for DNS with no path gateway configured still gets a
+      // native URI, never an empty link.
       return subdomainLink(publicSubdomainGateway || '', namespace, subdomainLabel, filename) ||
-        pathLink(publicGateway || '', namespace, pathId, filename)
+        pathLink(publicGateway || '', namespace, pathId, filename) ||
+        `${namespace}://${subdomainLabel}${filename}`
     default:
       return ''
   }
+}
+
+/**
+ * Local gateway link for opening content in a new tab (file preview and IPNS
+ * key links). Honors the Share Link type from Settings: the localhost
+ * subdomain form (per-content origin, so untrusted content cannot touch
+ * another CID's cookies or storage) when the user chose the local subdomain
+ * gateway, the IP path form otherwise. Returns '' when there is no local
+ * gateway.
+ *
+ * @param {object} opts
+ * @param {string} opts.shareLinkType - the stored SHARE_LINK_TYPE
+ * @param {string} opts.namespace - 'ipfs' or 'ipns'
+ * @param {string} opts.pathId - identifier for path links (CID or IPNS name)
+ * @param {string} opts.subdomainLabel - base32 CIDv1 or base36 IPNS name
+ * @param {string} [opts.filename] - `?filename=...` query, or ''
+ * @param {string} opts.localGatewayUrl - local gateway only, no public fallback
+ * @returns {string}
+ */
+export function getLocalContentLink ({ shareLinkType, namespace, pathId, subdomainLabel, filename = '', localGatewayUrl }) {
+  const type = shareLinkType === SHARE_LINK_TYPE.LOCAL_SUBDOMAIN
+    ? SHARE_LINK_TYPE.LOCAL_SUBDOMAIN
+    : SHARE_LINK_TYPE.LOCAL_PATH
+  return buildShareLink({ type, namespace, pathId, subdomainLabel, filename, localGatewayUrl })
 }
 
 /**
@@ -230,15 +312,19 @@ export function toIpnsBase36 (name) {
 }
 
 /**
- * Resolve the link type actually used. A public type with its gateway cleared
- * falls back to native (ipfs://), so links never silently break or point at an
- * unconfigured gateway.
+ * Resolve the link type actually used. A type whose gateway is not configured
+ * (a public type with its gateway cleared, or a local type with no local
+ * gateway at all) falls back to native (ipfs://), so links never silently
+ * break or point at an unconfigured gateway. buildShareLink is guaranteed to
+ * return a non-empty link for the type this resolves to.
  *
  * @param {string} type - the stored SHARE_LINK_TYPE
- * @param {{publicGateway: string, publicSubdomainGateway: string}} gateways
+ * @param {{publicGateway: string, publicSubdomainGateway: string, localGatewayUrl: string}} gateways
  * @returns {string} the effective SHARE_LINK_TYPE
  */
-export function resolveEffectiveShareLinkType (type, { publicGateway, publicSubdomainGateway }) {
+export function resolveEffectiveShareLinkType (type, { publicGateway, publicSubdomainGateway, localGatewayUrl }) {
+  const isLocal = type === SHARE_LINK_TYPE.LOCAL_PATH || type === SHARE_LINK_TYPE.LOCAL_SUBDOMAIN
+  if (isLocal && !localGatewayUrl) return SHARE_LINK_TYPE.NATIVE
   if (type === SHARE_LINK_TYPE.PUBLIC_PATH && !publicGateway) return SHARE_LINK_TYPE.NATIVE
   if (type === SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN && !publicSubdomainGateway) return SHARE_LINK_TYPE.NATIVE
   return type

--- a/src/lib/share-link.js
+++ b/src/lib/share-link.js
@@ -24,9 +24,12 @@ export const SHARE_LINK_TYPE = {
   PUBLIC_SUBDOMAIN: 'public-subdomain'
 }
 
-// Default to native ipfs:// URIs: a fresh node shares app-agnostic addresses
-// rather than routing through a third-party public gateway until the user opts in.
-export const DEFAULT_SHARE_LINK_TYPE = SHARE_LINK_TYPE.NATIVE
+// A fresh node shares links through the default public subdomain gateway
+// (DEFAULT_SUBDOMAIN_GATEWAY in bundles/gateway.js). To ship native ipfs://
+// sharing by default instead, flip this to SHARE_LINK_TYPE.NATIVE and empty
+// the DEFAULT_*_GATEWAY constants; everything else already copes with unset
+// gateways (see resolveEffectiveShareLinkType).
+export const DEFAULT_SHARE_LINK_TYPE = SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN
 
 // A subdomain gateway puts the CID (or IPNS name) in a DNS label, which is
 // capped at 63 characters.

--- a/src/lib/share-link.js
+++ b/src/lib/share-link.js
@@ -1,0 +1,245 @@
+// Import via 'multiformats/basics' rather than the per-encoding subpaths: the
+// subpaths only ship an ESM `exports` condition, which the app's Jest resolver
+// mis-resolves to the package root (leaving e.g. base36 undefined).
+import { CID, bases, digest as Digest } from 'multiformats/basics'
+
+const { base36, base58btc } = bases
+
+/**
+ * @typedef {import('../bundles/files/actions').FileStat} FileStat
+ */
+
+// libp2p-key multicodec, the codec of an IPNS name expressed as a CID.
+const LIBP2P_KEY_CODEC = 0x72
+
+/**
+ * The kinds of link the Share Link and Publish to IPNS flows can produce. The
+ * value is what we persist in localStorage, so keep these strings stable.
+ */
+export const SHARE_LINK_TYPE = {
+  NATIVE: 'native',
+  LOCAL_PATH: 'local-path',
+  LOCAL_SUBDOMAIN: 'local-subdomain',
+  PUBLIC_PATH: 'public-path',
+  PUBLIC_SUBDOMAIN: 'public-subdomain'
+}
+
+// Default to native ipfs:// URIs: a fresh node shares app-agnostic addresses
+// rather than routing through a third-party public gateway until the user opts in.
+export const DEFAULT_SHARE_LINK_TYPE = SHARE_LINK_TYPE.NATIVE
+
+// A subdomain gateway puts the CID (or IPNS name) in a DNS label, which is
+// capped at 63 characters.
+const DNS_LABEL_MAX = 63
+
+// Loopback hosts reach the same local node, so local links use canonical forms:
+// the IP for path links (no DNS needed) and localhost for subdomain links
+// (subdomain origins need a hostname). https://github.com/ipfs/ipfs-webui/issues/1490
+const LOOPBACK_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0', '[::1]', '[::]'])
+const LOOPBACK_IP = '127.0.0.1'
+const LOOPBACK_HOSTNAME = 'localhost'
+
+/**
+ * Build the `?filename=...` query that hints a gateway at a download name.
+ * Only a single file gets one; directories and multi-file selections do not.
+ *
+ * @param {FileStat[]} files
+ * @returns {string} the query string, or '' when no filename hint applies
+ */
+export function getFilenameQuery (files) {
+  if (files.length === 1 && files[0].type === 'file') {
+    return `?filename=${encodeURIComponent(files[0].name)}`
+  }
+  return ''
+}
+
+/**
+ * Whether a URL hostname is a bare IP literal rather than a domain name.
+ * Subdomain gateways serve one origin per CID under a parent domain, so they
+ * cannot be built on an IP such as 192.168.1.5.
+ *
+ * @param {string} hostname - a URL hostname (IPv6 keeps its surrounding brackets)
+ * @returns {boolean}
+ */
+function isIpHostname (hostname) {
+  // IPv6 literals are bracketed in a URL hostname, e.g. [::1]
+  if (hostname.startsWith('[')) {
+    return true
+  }
+  // IPv4 dotted quad, e.g. 127.0.0.1
+  return /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)
+}
+
+/**
+ * Build a path gateway link: `<gateway>/<namespace>/<id>`.
+ *
+ * @param {string} gatewayUrl
+ * @param {string} namespace - 'ipfs' or 'ipns'
+ * @param {string} id - CID string or IPNS name
+ * @param {string} filename - `?filename=...` query, or ''
+ * @param {{loopback?: boolean}} [opts] - normalize a loopback host to 127.0.0.1
+ * @returns {string} the link, or '' when gatewayUrl is empty
+ */
+function pathLink (gatewayUrl, namespace, id, filename, opts = {}) {
+  if (!gatewayUrl) return ''
+  const url = new URL(gatewayUrl)
+  let host = url.host
+  if (opts.loopback && LOOPBACK_HOSTNAMES.has(url.hostname)) {
+    const port = url.port ? `:${url.port}` : ''
+    host = `${LOOPBACK_IP}${port}`
+  }
+  // Preserve any subpath the gateway is mounted under (e.g. a reverse proxy at
+  // https://example.com/gw); '/' collapses to an empty base.
+  const base = url.pathname.replace(/\/+$/, '')
+  return `${url.protocol}//${host}${base}/${namespace}/${id}${filename}`
+}
+
+/**
+ * Build a subdomain gateway link: `<label>.<namespace>.<gateway-host>`, giving
+ * the content its own origin. Returns '' when it cannot be represented: no
+ * gateway, a label longer than a DNS label allows, or a host that is a bare IP.
+ *
+ * @param {string} gatewayUrl
+ * @param {string} namespace - 'ipfs' or 'ipns'
+ * @param {string} label - base32 CIDv1 or IPNS name to place in the DNS label
+ * @param {string} filename - `?filename=...` query, or ''
+ * @param {{loopback?: boolean}} [opts] - normalize a loopback host to localhost
+ * @returns {string}
+ */
+function subdomainLink (gatewayUrl, namespace, label, filename, opts = {}) {
+  if (!gatewayUrl || !label || label.length > DNS_LABEL_MAX) return ''
+  const url = new URL(gatewayUrl)
+  let hostname = url.hostname
+  if (opts.loopback && LOOPBACK_HOSTNAMES.has(hostname)) hostname = LOOPBACK_HOSTNAME
+  if (isIpHostname(hostname)) return ''
+  const port = url.port ? `:${url.port}` : ''
+  return `${url.protocol}//${label}.${namespace}.${hostname}${port}${filename}`
+}
+
+/**
+ * Build a single content link of the requested type, for the `/ipfs` (Share
+ * Link) or `/ipns` (Publish to IPNS) namespace. Public subdomain links fall
+ * back to the public path gateway when the label is too long for DNS; local
+ * subdomain links fall back to the local path link. Returns '' when the type
+ * cannot be built (e.g. a public type with no public gateway configured).
+ *
+ * @param {object} opts
+ * @param {string} opts.type - a SHARE_LINK_TYPE value
+ * @param {string} opts.namespace - 'ipfs' or 'ipns'
+ * @param {string} opts.pathId - identifier for path links (CID or IPNS name)
+ * @param {string} opts.subdomainLabel - the canonical v1 form used for subdomain
+ *   and native links (base32 CIDv1 for /ipfs, base36 libp2p-key for /ipns)
+ * @param {string} [opts.filename] - `?filename=...` query, or ''
+ * @param {string} opts.localGatewayUrl - local gateway, honoring the user override
+ * @param {string} [opts.publicGateway] - public path gateway; may be '' or omitted for local/native types
+ * @param {string} [opts.publicSubdomainGateway] - public subdomain gateway; may be '' or omitted for local/native types
+ * @returns {string}
+ */
+export function buildShareLink ({ type, namespace, pathId, subdomainLabel, filename = '', localGatewayUrl, publicGateway, publicSubdomainGateway }) {
+  switch (type) {
+    case SHARE_LINK_TYPE.NATIVE:
+      // Native URIs use the canonical v1 form: a base32 CIDv1 for /ipfs (so a
+      // CIDv0 Qm... becomes bafy...) and a base36 libp2p-key for /ipns. The
+      // filename query is kept so a resolver (e.g. IPFS Companion) forwards it
+      // to the gateway as the download name.
+      return `${namespace}://${subdomainLabel}${filename}`
+    case SHARE_LINK_TYPE.LOCAL_PATH:
+      return pathLink(localGatewayUrl, namespace, pathId, filename, { loopback: true })
+    case SHARE_LINK_TYPE.LOCAL_SUBDOMAIN:
+      return subdomainLink(localGatewayUrl, namespace, subdomainLabel, filename, { loopback: true }) ||
+        pathLink(localGatewayUrl, namespace, pathId, filename, { loopback: true })
+    case SHARE_LINK_TYPE.PUBLIC_PATH:
+      return pathLink(publicGateway || '', namespace, pathId, filename)
+    case SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN:
+      return subdomainLink(publicSubdomainGateway || '', namespace, subdomainLabel, filename) ||
+        pathLink(publicGateway || '', namespace, pathId, filename)
+    default:
+      return ''
+  }
+}
+
+/**
+ * The local path and subdomain links for a CID, used by the Share modal to
+ * offer a local link even when the configured type is native or public. The
+ * subdomain link is '' when the CID cannot be represented as one.
+ *
+ * @param {CID} cid - root CID
+ * @param {string} filename - `?filename=...` query, or ''
+ * @param {string} localGatewayUrl
+ * @returns {{localLink: string, subdomainLocalLink: string}}
+ */
+export function getLocalLinks (cid, filename, localGatewayUrl) {
+  return {
+    localLink: pathLink(localGatewayUrl, 'ipfs', cid.toString(), filename, { loopback: true }),
+    subdomainLocalLink: subdomainLink(localGatewayUrl, 'ipfs', cid.toV1().toString(), filename, { loopback: true })
+  }
+}
+
+/**
+ * An example local link, with a literal "CID" placeholder, showing the shape a
+ * local option produces (e.g. http://127.0.0.1:8080/ipfs/CID for path, or
+ * http://CID.ipfs.localhost:8080 for subdomain). Shown in Settings so users can
+ * see what a local option will build. Returns '' when the gateway is unusable.
+ *
+ * @param {string} gatewayUrl - the local gateway URL (honors the user override)
+ * @param {{subdomain?: boolean}} [opts]
+ * @returns {string}
+ */
+export function gatewayExample (gatewayUrl, opts = {}) {
+  try {
+    return buildShareLink({
+      type: opts.subdomain ? SHARE_LINK_TYPE.LOCAL_SUBDOMAIN : SHARE_LINK_TYPE.LOCAL_PATH,
+      namespace: 'ipfs',
+      pathId: 'CID',
+      subdomainLabel: 'CID',
+      localGatewayUrl: gatewayUrl
+    })
+  } catch {
+    // Malformed gateway URL: skip the example rather than throwing.
+    return ''
+  }
+}
+
+/**
+ * Normalize an IPNS name to a base36 libp2p-key CIDv1 (k51...), the form
+ * gateways expect in subdomains and native ipns:// URIs. Accepts a name that is
+ * already such a CID, a base32 libp2p-key CID, or a base58btc PeerID
+ * (12D3Koo... for ed25519, Qm... for RSA). Returns the input unchanged when it
+ * cannot be parsed as either.
+ *
+ * @param {string} name
+ * @returns {string}
+ */
+export function toIpnsBase36 (name) {
+  try {
+    const cid = CID.parse(name)
+    if (cid.code === LIBP2P_KEY_CODEC) {
+      return cid.toV1().toString(base36)
+    }
+  } catch {
+    // Not a CID string; fall through to the PeerID path below.
+  }
+  try {
+    // A PeerID is a base58btc multihash with no multibase prefix.
+    const digest = Digest.decode(base58btc.decode(`z${name}`))
+    return CID.createV1(LIBP2P_KEY_CODEC, digest).toString(base36)
+  } catch {
+    // Leave unrecognized input untouched rather than breaking the link.
+    return name
+  }
+}
+
+/**
+ * Resolve the link type actually used. A public type with its gateway cleared
+ * falls back to native (ipfs://), so links never silently break or point at an
+ * unconfigured gateway.
+ *
+ * @param {string} type - the stored SHARE_LINK_TYPE
+ * @param {{publicGateway: string, publicSubdomainGateway: string}} gateways
+ * @returns {string} the effective SHARE_LINK_TYPE
+ */
+export function resolveEffectiveShareLinkType (type, { publicGateway, publicSubdomainGateway }) {
+  if (type === SHARE_LINK_TYPE.PUBLIC_PATH && !publicGateway) return SHARE_LINK_TYPE.NATIVE
+  if (type === SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN && !publicSubdomainGateway) return SHARE_LINK_TYPE.NATIVE
+  return type
+}

--- a/src/lib/share-link.test.js
+++ b/src/lib/share-link.test.js
@@ -4,9 +4,11 @@ import {
   SHARE_LINK_TYPE,
   buildShareLink,
   getLocalLinks,
+  getLocalContentLink,
   getFilenameQuery,
   resolveEffectiveShareLinkType,
   toIpnsBase36,
+  toLoopbackIpUrl,
   gatewayExample
 } from './share-link.js'
 
@@ -58,10 +60,26 @@ describe('buildShareLink for /ipfs', () => {
 
   it('local path uses the loopback IP', () => {
     expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH)).toBe(`http://127.0.0.1:8080/ipfs/${cid}?filename=example.txt`)
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH, { localGatewayUrl: 'http://localhost:8080' })).toBe(`http://127.0.0.1:8080/ipfs/${cid}?filename=example.txt`)
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH, { localGatewayUrl: 'http://0.0.0.0:8080' })).toBe(`http://127.0.0.1:8080/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('local path keeps the IPv6 address family', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH, { localGatewayUrl: 'http://[::1]:8080' })).toBe(`http://[::1]:8080/ipfs/${cid}?filename=example.txt`)
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH, { localGatewayUrl: 'http://[::]:8080' })).toBe(`http://[::1]:8080/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('local path does not rewrite an https loopback host (TLS cert covers the exact hostname)', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH, { localGatewayUrl: 'https://localhost:8443' })).toBe(`https://localhost:8443/ipfs/${cid}?filename=example.txt`)
   })
 
   it('local subdomain uses localhost', () => {
     expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)).toBe(`http://${CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { localGatewayUrl: 'http://[::1]:8080' })).toBe(`http://${CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+  })
+
+  it('local subdomain does not rewrite an https loopback IP, falling back to the path link', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { localGatewayUrl: 'https://127.0.0.1:8443' })).toBe(`https://127.0.0.1:8443/ipfs/${cid}?filename=example.txt`)
   })
 
   it('local subdomain falls back to the local path for a non-loopback IP gateway', () => {
@@ -93,6 +111,20 @@ describe('buildShareLink for /ipfs', () => {
       publicSubdomainGateway: PUBLIC_SUBDOMAIN
     })
     expect(link).toBe(`https://ipfs.io/ipfs/${LONG_CID}`)
+  })
+
+  it('public subdomain falls back to a native URI for an over-long CID with no path gateway', () => {
+    const link = buildShareLink({
+      type: SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN,
+      namespace: 'ipfs',
+      pathId: LONG_CID.toString(),
+      subdomainLabel: LONG_CID.toV1().toString(),
+      filename: '',
+      localGatewayUrl: LOCAL,
+      publicGateway: '',
+      publicSubdomainGateway: PUBLIC_SUBDOMAIN
+    })
+    expect(link).toBe(`ipfs://${LONG_CID.toV1()}`)
   })
 
   it('local subdomain falls back to the local path for an over-long CID', () => {
@@ -152,6 +184,44 @@ describe('getLocalLinks', () => {
   })
 })
 
+describe('getLocalContentLink', () => {
+  it('uses the subdomain form only when the user chose the local subdomain type', () => {
+    const opts = { namespace: 'ipfs', pathId: cid.toString(), subdomainLabel: cid.toV1().toString(), localGatewayUrl: 'http://localhost:8080' }
+    expect(getLocalContentLink({ shareLinkType: SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, ...opts })).toBe(`http://${CID_BASE32}.ipfs.localhost:8080`)
+    expect(getLocalContentLink({ shareLinkType: SHARE_LINK_TYPE.NATIVE, ...opts })).toBe(`http://127.0.0.1:8080/ipfs/${cid}`)
+    expect(getLocalContentLink({ shareLinkType: SHARE_LINK_TYPE.PUBLIC_PATH, ...opts })).toBe(`http://127.0.0.1:8080/ipfs/${cid}`)
+  })
+
+  it('returns empty when there is no local gateway', () => {
+    expect(getLocalContentLink({ shareLinkType: SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, namespace: 'ipfs', pathId: cid.toString(), subdomainLabel: cid.toV1().toString(), localGatewayUrl: '' })).toBe('')
+  })
+})
+
+describe('toLoopbackIpUrl', () => {
+  it('rewrites http loopback hosts to 127.0.0.1', () => {
+    expect(toLoopbackIpUrl('http://localhost:8080/ipfs/bafy?filename=a.txt')).toBe('http://127.0.0.1:8080/ipfs/bafy?filename=a.txt')
+    expect(toLoopbackIpUrl('http://localhost/ipfs/bafy')).toBe('http://127.0.0.1/ipfs/bafy')
+    expect(toLoopbackIpUrl('http://0.0.0.0:8080/ipfs/bafy')).toBe('http://127.0.0.1:8080/ipfs/bafy')
+  })
+
+  it('rewrites http IPv6 loopback to [::1]', () => {
+    expect(toLoopbackIpUrl('http://[::]:8080/ipfs/bafy')).toBe('http://[::1]:8080/ipfs/bafy')
+    expect(toLoopbackIpUrl('http://[::1]:8080/ipfs/bafy')).toBe('http://[::1]:8080/ipfs/bafy')
+  })
+
+  it('keeps a bare gateway root free of a trailing slash', () => {
+    expect(toLoopbackIpUrl('http://localhost:8080')).toBe('http://127.0.0.1:8080')
+  })
+
+  it('leaves other hosts, schemes, and non-URLs unchanged', () => {
+    expect(toLoopbackIpUrl('http://127.0.0.1:8080/ipfs/bafy')).toBe('http://127.0.0.1:8080/ipfs/bafy')
+    expect(toLoopbackIpUrl('https://dweb.link/ipfs/bafy')).toBe('https://dweb.link/ipfs/bafy')
+    expect(toLoopbackIpUrl('https://localhost:8080/ipfs/bafy')).toBe('https://localhost:8080/ipfs/bafy')
+    expect(toLoopbackIpUrl('http://localhostx:8080/ipfs/bafy')).toBe('http://localhostx:8080/ipfs/bafy')
+    expect(toLoopbackIpUrl('/ipfs/bafy')).toBe('/ipfs/bafy')
+  })
+})
+
 describe('getFilenameQuery', () => {
   it('builds a query for a single file', () => {
     expect(getFilenameQuery([{ type: 'file', name: 'a b.txt' }])).toBe('?filename=a%20b.txt')
@@ -202,12 +272,17 @@ describe('toIpnsBase36', () => {
 
 describe('resolveEffectiveShareLinkType', () => {
   it('keeps the type when its gateway is set', () => {
-    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: 'https://dweb.link' })).toBe(SHARE_LINK_TYPE.PUBLIC_PATH)
-    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { publicGateway: '', publicSubdomainGateway: '' })).toBe(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: 'https://dweb.link', localGatewayUrl: '' })).toBe(SHARE_LINK_TYPE.PUBLIC_PATH)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { publicGateway: '', publicSubdomainGateway: '', localGatewayUrl: LOCAL })).toBe(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)
   })
 
   it('falls back to native when the chosen public gateway is empty', () => {
-    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: '', publicSubdomainGateway: 'https://dweb.link' })).toBe(SHARE_LINK_TYPE.NATIVE)
-    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: '' })).toBe(SHARE_LINK_TYPE.NATIVE)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: '', publicSubdomainGateway: 'https://dweb.link', localGatewayUrl: LOCAL })).toBe(SHARE_LINK_TYPE.NATIVE)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: '', localGatewayUrl: LOCAL })).toBe(SHARE_LINK_TYPE.NATIVE)
+  })
+
+  it('falls back to native for a local type with no local gateway', () => {
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.LOCAL_PATH, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: '', localGatewayUrl: '' })).toBe(SHARE_LINK_TYPE.NATIVE)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { publicGateway: '', publicSubdomainGateway: 'https://dweb.link', localGatewayUrl: '' })).toBe(SHARE_LINK_TYPE.NATIVE)
   })
 })

--- a/src/lib/share-link.test.js
+++ b/src/lib/share-link.test.js
@@ -1,0 +1,213 @@
+/* global describe, it, expect */
+import { CID } from 'multiformats/cid'
+import {
+  SHARE_LINK_TYPE,
+  buildShareLink,
+  getLocalLinks,
+  getFilenameQuery,
+  resolveEffectiveShareLinkType,
+  toIpnsBase36,
+  gatewayExample
+} from './share-link.js'
+
+const cid = CID.parse('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')
+const CID_BASE32 = 'bafybeifffq3aeaymxejo37sn5fyaf7nn7hkfmzwdxyjculx3lw4tyhk7uy'
+// A base32 CIDv1 whose label exceeds the 63-char DNS limit, so it cannot be a
+// subdomain label and must fall back to a path link.
+const LONG_CID = CID.parse('bagaaifcavabu6fzheerrmtxbbwv7jjhc3kaldmm7lbnvfopyrthcvod4m6ygpj3unrcggkzhvcwv5wnhc5ufkgzlsji7agnmofovc2g4a3ui7ja')
+const IPNS_NAME = 'k51qzi5uqu5dl2yn0d6xu8q5aqa61jh8zeyixz9tsju80n15ssiyew48912c63'
+
+// Reachable gateways shared across the link-type cases below.
+const LOCAL = 'http://127.0.0.1:8080'
+const PUBLIC_PATH = 'https://ipfs.io'
+const PUBLIC_SUBDOMAIN = 'https://dweb.link'
+
+const ipfsLink = (type, overrides = {}) => buildShareLink({
+  type,
+  namespace: 'ipfs',
+  pathId: cid.toString(),
+  subdomainLabel: cid.toV1().toString(),
+  filename: '?filename=example.txt',
+  localGatewayUrl: LOCAL,
+  publicGateway: PUBLIC_PATH,
+  publicSubdomainGateway: PUBLIC_SUBDOMAIN,
+  ...overrides
+})
+
+const ipnsLink = (type, overrides = {}) => buildShareLink({
+  type,
+  namespace: 'ipns',
+  pathId: IPNS_NAME,
+  subdomainLabel: IPNS_NAME,
+  filename: '',
+  localGatewayUrl: LOCAL,
+  publicGateway: PUBLIC_PATH,
+  publicSubdomainGateway: PUBLIC_SUBDOMAIN,
+  ...overrides
+})
+
+describe('buildShareLink for /ipfs', () => {
+  it('native uses an ipfs:// URI with a base32 CIDv1 (converts CIDv0) and keeps the filename', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.NATIVE)).toBe(`ipfs://${CID_BASE32}?filename=example.txt`)
+  })
+
+  it('preserves a gateway mounted under a subpath', () => {
+    const link = ipfsLink(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: 'https://example.com/gw' })
+    expect(link).toBe(`https://example.com/gw/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('local path uses the loopback IP', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_PATH)).toBe(`http://127.0.0.1:8080/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('local subdomain uses localhost', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)).toBe(`http://${CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+  })
+
+  it('local subdomain falls back to the local path for a non-loopback IP gateway', () => {
+    const link = ipfsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { localGatewayUrl: 'http://192.168.1.5:8080' })
+    expect(link).toBe(`http://192.168.1.5:8080/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('public path uses the public path gateway', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.PUBLIC_PATH)).toBe(`https://ipfs.io/ipfs/${cid}?filename=example.txt`)
+  })
+
+  it('public subdomain uses the public subdomain gateway', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)).toBe(`https://${CID_BASE32}.ipfs.dweb.link?filename=example.txt`)
+  })
+
+  it('public path is empty when no public path gateway is set', () => {
+    expect(ipfsLink(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: '' })).toBe('')
+  })
+
+  it('public subdomain falls back to the public path gateway for an over-long CID', () => {
+    const link = buildShareLink({
+      type: SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN,
+      namespace: 'ipfs',
+      pathId: LONG_CID.toString(),
+      subdomainLabel: LONG_CID.toV1().toString(),
+      filename: '',
+      localGatewayUrl: LOCAL,
+      publicGateway: PUBLIC_PATH,
+      publicSubdomainGateway: PUBLIC_SUBDOMAIN
+    })
+    expect(link).toBe(`https://ipfs.io/ipfs/${LONG_CID}`)
+  })
+
+  it('local subdomain falls back to the local path for an over-long CID', () => {
+    const link = buildShareLink({
+      type: SHARE_LINK_TYPE.LOCAL_SUBDOMAIN,
+      namespace: 'ipfs',
+      pathId: LONG_CID.toString(),
+      subdomainLabel: LONG_CID.toV1().toString(),
+      filename: '',
+      localGatewayUrl: LOCAL,
+      publicGateway: PUBLIC_PATH,
+      publicSubdomainGateway: PUBLIC_SUBDOMAIN
+    })
+    expect(link).toBe(`http://127.0.0.1:8080/ipfs/${LONG_CID}`)
+  })
+})
+
+describe('buildShareLink for /ipns', () => {
+  it('native uses an ipns:// URI', () => {
+    expect(ipnsLink(SHARE_LINK_TYPE.NATIVE)).toBe(`ipns://${IPNS_NAME}`)
+  })
+
+  it('local path uses the loopback IP', () => {
+    expect(ipnsLink(SHARE_LINK_TYPE.LOCAL_PATH)).toBe(`http://127.0.0.1:8080/ipns/${IPNS_NAME}`)
+  })
+
+  it('local subdomain uses localhost', () => {
+    expect(ipnsLink(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)).toBe(`http://${IPNS_NAME}.ipns.localhost:8080`)
+  })
+
+  it('public path uses the public path gateway', () => {
+    expect(ipnsLink(SHARE_LINK_TYPE.PUBLIC_PATH)).toBe(`https://ipfs.io/ipns/${IPNS_NAME}`)
+  })
+
+  it('public subdomain uses the public subdomain gateway', () => {
+    expect(ipnsLink(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN)).toBe(`https://${IPNS_NAME}.ipns.dweb.link`)
+  })
+})
+
+describe('getLocalLinks', () => {
+  it('returns a loopback path link and a localhost subdomain link', () => {
+    const { localLink, subdomainLocalLink } = getLocalLinks(cid, '?filename=example.txt', 'http://127.0.0.1:8080')
+    expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${cid}?filename=example.txt`)
+    expect(subdomainLocalLink).toBe(`http://${CID_BASE32}.ipfs.localhost:8080?filename=example.txt`)
+  })
+
+  it('returns an empty subdomain link for a non-loopback IP gateway', () => {
+    const { localLink, subdomainLocalLink } = getLocalLinks(cid, '', 'http://192.168.1.5:8080')
+    expect(localLink).toBe(`http://192.168.1.5:8080/ipfs/${cid}`)
+    expect(subdomainLocalLink).toBe('')
+  })
+
+  it('returns an empty subdomain link for an over-long CID', () => {
+    const { localLink, subdomainLocalLink } = getLocalLinks(LONG_CID, '', 'http://127.0.0.1:8080')
+    expect(localLink).toBe(`http://127.0.0.1:8080/ipfs/${LONG_CID}`)
+    expect(subdomainLocalLink).toBe('')
+  })
+})
+
+describe('getFilenameQuery', () => {
+  it('builds a query for a single file', () => {
+    expect(getFilenameQuery([{ type: 'file', name: 'a b.txt' }])).toBe('?filename=a%20b.txt')
+  })
+
+  it('returns empty for a directory or multiple files', () => {
+    expect(getFilenameQuery([{ type: 'directory', name: 'dir' }])).toBe('')
+    expect(getFilenameQuery([{ type: 'file', name: 'a' }, { type: 'file', name: 'b' }])).toBe('')
+  })
+})
+
+describe('gatewayExample', () => {
+  it('shows a CID-placeholder path link on the loopback IP', () => {
+    expect(gatewayExample('http://127.0.0.1:8080')).toBe('http://127.0.0.1:8080/ipfs/CID')
+    expect(gatewayExample('http://localhost:8080')).toBe('http://127.0.0.1:8080/ipfs/CID')
+  })
+
+  it('shows a CID-placeholder subdomain link on localhost', () => {
+    expect(gatewayExample('http://127.0.0.1:8080', { subdomain: true })).toBe('http://CID.ipfs.localhost:8080')
+  })
+
+  it('keeps a non-loopback gateway host', () => {
+    expect(gatewayExample('https://gw.example.com')).toBe('https://gw.example.com/ipfs/CID')
+    expect(gatewayExample('https://gw.example.com', { subdomain: true })).toBe('https://CID.ipfs.gw.example.com')
+  })
+})
+
+describe('toIpnsBase36', () => {
+  it('keeps a base36 libp2p-key name unchanged', () => {
+    expect(toIpnsBase36(IPNS_NAME)).toBe(IPNS_NAME)
+  })
+
+  it('converts an ed25519 PeerID to a base36 libp2p-key', () => {
+    expect(toIpnsBase36('12D3KooWD3eckifWpRn9wQpMG9R9hX3sD158z7EqHWmweQAJU5SA')).toMatch(/^k51/)
+  })
+
+  it('converts an RSA Qm PeerID to a base36 libp2p-key, not a dag-pb CID', () => {
+    // Qm... parses as a dag-pb CIDv0, but as an IPNS name it is a PeerID, so it
+    // must become a libp2p-key CID (base36 k2k4...), never a dag-pb one.
+    expect(toIpnsBase36('QmZTR5bcpQD7cFgTorqxZDYaew1Wqgfbd2ud9QqGPAkK2V')).toMatch(/^k2k4/)
+  })
+
+  it('returns unrecognized input unchanged without throwing', () => {
+    expect(toIpnsBase36('not-a-name')).toBe('not-a-name')
+    expect(() => toIpnsBase36('')).not.toThrow()
+  })
+})
+
+describe('resolveEffectiveShareLinkType', () => {
+  it('keeps the type when its gateway is set', () => {
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: 'https://dweb.link' })).toBe(SHARE_LINK_TYPE.PUBLIC_PATH)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN, { publicGateway: '', publicSubdomainGateway: '' })).toBe(SHARE_LINK_TYPE.LOCAL_SUBDOMAIN)
+  })
+
+  it('falls back to native when the chosen public gateway is empty', () => {
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_PATH, { publicGateway: '', publicSubdomainGateway: 'https://dweb.link' })).toBe(SHARE_LINK_TYPE.NATIVE)
+    expect(resolveEffectiveShareLinkType(SHARE_LINK_TYPE.PUBLIC_SUBDOMAIN, { publicGateway: 'https://ipfs.io', publicSubdomainGateway: '' })).toBe(SHARE_LINK_TYPE.NATIVE)
+  })
+})

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -16,9 +16,8 @@ import PinningManager from '../components/pinning-manager/PinningManager.js'
 import IpnsManager from '../components/ipns-manager/IpnsManager.js'
 import AnalyticsToggle from '../components/analytics-toggle/AnalyticsToggle.js'
 import ApiAddressForm from '../components/api-address-form/api-address-form'
-import PublicGatewayForm from '../components/public-gateway-form/PublicGatewayForm.js'
-import PublicSubdomainGatewayForm from '../components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js'
 import LocalGatewayForm from '../components/local-gateway-form/LocalGatewayForm.js'
+import ShareLinkTypeForm from '../components/share-link-type-form/ShareLinkTypeForm.js'
 import IpfsCheckForm from '../components/ipfs-check-form/IpfsCheckForm.js'
 import { JsonEditor } from './editor/JsonEditor.js'
 import Experiments from '../components/experiments/ExperimentsPanel.js'
@@ -60,7 +59,7 @@ export const SettingsPage = ({
         <div className='lh-copy charcoal'>
           <Title>{t('app:terms.apiAddress')}</Title>
           <Trans i18nKey='apiDescription' t={t}>
-            <p>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesapi' target='_blank' rel='noopener noreferrer'>custom Kubo RPC API address</a>, including a port other than the default 5001, enter it here.</p>
+            <p className='f6'>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesapi' target='_blank' rel='noopener noreferrer'>custom Kubo RPC API address</a>, including a port other than the default 5001, enter it here.</p>
           </Trans>
           <ApiAddressForm/>
         </div>
@@ -70,22 +69,23 @@ export const SettingsPage = ({
       <div className='lh-copy charcoal'>
         <Title>{t('app:terms.localGateway')}</Title>
         <Trans i18nKey='localGatewayDescription' t={t}>
-          <p>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesgateway' target='_blank' rel='noopener noreferrer'>gateway address</a> from your Kubo config.</p>
+          <p className='f6'>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesgateway' target='_blank' rel='noopener noreferrer'>gateway address</a> from your Kubo config.</p>
         </Trans>
         <LocalGatewayForm/>
       </div>
-      <div className='lh-copy charcoal mt4'>
-        <Title>{t('app:terms.publicGateway')}</Title>
-        <Trans i18nKey='publicSubdomainGatewayDescription' t={t}>
-          <p>Select a default <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#subdomain' target='_blank' rel='noopener noreferrer'>Subdomain Gateway</a> for generating shareable links.</p>
-        </Trans>
-        <PublicSubdomainGatewayForm/>
-      </div>
+    </Box>
+
+    <Box className='mb3 pa4-l pa2'>
       <div className='lh-copy charcoal'>
-        <Trans i18nKey='publicPathGatewayDescription' t={t}>
-          <p>Select a fallback <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#path' target='_blank' rel='noopener noreferrer'>Path Gateway</a> for generating shareable links for CIDs that exceed the 63-character DNS limit.</p>
-        </Trans>
-        <PublicGatewayForm/>
+        <Title>{t('shareLink.title')}</Title>
+        <p className='charcoal lh-copy f6'>{t('shareLink.intro')}</p>
+        <p className='charcoal lh-copy f6'>
+          <Trans i18nKey='shareLink.pathVsSubdomain' t={t}>
+            <a className='link blue' href='https://specs.ipfs.tech/http-gateways/path-gateway/' target='_blank' rel='noopener noreferrer'>path</a>
+            <a className='link blue' href='https://specs.ipfs.tech/http-gateways/subdomain-gateway/' target='_blank' rel='noopener noreferrer'>subdomain</a>
+          </Trans>
+        </p>
+        <ShareLinkTypeForm/>
       </div>
     </Box>
 

--- a/test/e2e/ipns.test.js
+++ b/test/e2e/ipns.test.js
@@ -144,8 +144,9 @@ test.describe('IPNS publishing', () => {
       // IPNS publishing can take time depending on network/DHT conditions
       await expect(page.getByText('Successfully published')).toBeVisible({ timeout: 30000 })
 
-      // Default share link type is native, so the published link is an ipns:// URI
-      await expect(page.locator('div[role="dialog"] input[readonly]')).toHaveValue(/^ipns:\/\//)
+      // Default share link type is the public subdomain gateway, so the
+      // published link puts the base36 IPNS name in a dweb.link subdomain
+      await expect(page.locator('div[role="dialog"] input[readonly]')).toHaveValue(/^https:\/\/k\w+\.ipns\.dweb\.link$/)
 
       await ipns.doneButton(page).click()
 

--- a/test/e2e/ipns.test.js
+++ b/test/e2e/ipns.test.js
@@ -143,6 +143,10 @@ test.describe('IPNS publishing', () => {
 
       // IPNS publishing can take time depending on network/DHT conditions
       await expect(page.getByText('Successfully published')).toBeVisible({ timeout: 30000 })
+
+      // Default share link type is native, so the published link is an ipns:// URI
+      await expect(page.locator('div[role="dialog"] input[readonly]')).toHaveValue(/^ipns:\/\//)
+
       await ipns.doneButton(page).click()
 
       // confirm IPNS record in local store points at the CID

--- a/test/e2e/settings.test.js
+++ b/test/e2e/settings.test.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import { test, expect } from './setup/coverage.js'
 import { settings } from './setup/locators.js'
-import { DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, TEST_PATH_GATEWAY, TEST_SUBDOMAIN_GATEWAY } from '../../src/bundles/gateway.js'
+import { TEST_PATH_GATEWAY, TEST_SUBDOMAIN_GATEWAY } from '../../src/bundles/gateway.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -22,24 +22,27 @@ test.describe('Settings screen', () => {
   })
 
   test('should show config of IPFS node', async ({ page }) => {
-    await expect(page.getByText('Addresses')).toBeVisible()
-    await expect(page.getByText('Bootstrap')).toBeVisible()
-    await expect(page.getByText('PeerID')).toBeVisible()
+    // Scope to the config editor and match whole JSON keys: these words appear
+    // as prose elsewhere on the page, and as substrings of other keys (e.g.
+    // "LoopbackAddressesOnLanDHT"), so an unscoped substring match is ambiguous.
+    const config = page.locator('.ace_editor')
+    await expect(config.getByText('"Addresses"', { exact: true })).toBeVisible()
+    await expect(config.getByText('"Bootstrap"', { exact: true })).toBeVisible()
+    await expect(config.getByText('"PeerID"', { exact: true })).toBeVisible()
     // check PeerID in config to confirm it comes from expected instance
     const id = process.env.IPFS_RPC_ID
-    await expect(page.getByText(id)).toBeVisible()
+    await expect(config.getByText(id)).toBeVisible()
   })
 
-  test('Submit/Reset Public Subdomain Gateway', async ({ page }) => {
+  test('Submit/Clear Public Subdomain Gateway', async ({ page }) => {
     const publicSubdomainGatewayElement = settings.publicSubdomainGateway(page)
     const publicSubdomainGatewaySubmitButton = page.locator('#public-subdomain-gateway-submit-button')
-    const publicSubdomainGatewayResetButton = page.locator('#public-subdomain-gateway-reset-button')
+    const publicSubdomainGatewayClearButton = page.locator('#public-subdomain-gateway-clear-button')
 
     await expect(publicSubdomainGatewayElement).toBeVisible()
 
-    // Store initial value (should be DEFAULT_SUBDOMAIN_GATEWAY)
-    const initialValue = await publicSubdomainGatewayElement.inputValue()
-    expect(initialValue).toBe(DEFAULT_SUBDOMAIN_GATEWAY)
+    // Empty by default; the user opts into a public gateway.
+    await expect(publicSubdomainGatewayElement).toHaveValue('')
 
     // First, set an invalid value to verify red border appears
     await publicSubdomainGatewayElement.click({ clickCount: 3 })
@@ -67,23 +70,20 @@ test.describe('Settings screen', () => {
     // Wait for value to persist
     await expect(publicSubdomainGatewayElement).toHaveValue(TEST_SUBDOMAIN_GATEWAY, { timeout: 5000 })
 
-    // Test reset button
-    await publicSubdomainGatewayResetButton.click()
-
-    // Verify reset to default
-    await expect(publicSubdomainGatewayElement).toHaveValue(DEFAULT_SUBDOMAIN_GATEWAY)
+    // Clear empties the field
+    await publicSubdomainGatewayClearButton.click()
+    await expect(publicSubdomainGatewayElement).toHaveValue('')
   })
 
-  test('Submit/Reset Public Path Gateway', async ({ page }) => {
+  test('Submit/Clear Public Path Gateway', async ({ page }) => {
     const publicGatewayElement = settings.publicPathGateway(page)
     const publicGatewaySubmitButton = page.locator('#public-path-gateway-submit-button')
-    const publicGatewayResetButton = page.locator('#public-path-gateway-reset-button')
+    const publicGatewayClearButton = page.locator('#public-path-gateway-clear-button')
 
     await expect(publicGatewayElement).toBeVisible()
 
-    // Store initial value (should be DEFAULT_PATH_GATEWAY)
-    const initialValue = await publicGatewayElement.inputValue()
-    expect(initialValue).toBe(DEFAULT_PATH_GATEWAY)
+    // Empty by default; the user opts into a public gateway.
+    await expect(publicGatewayElement).toHaveValue('')
 
     // First, set an invalid value to verify red border appears
     await publicGatewayElement.click({ clickCount: 3 })
@@ -111,17 +111,15 @@ test.describe('Settings screen', () => {
     // Wait for value to persist
     await expect(publicGatewayElement).toHaveValue(TEST_PATH_GATEWAY, { timeout: 5000 })
 
-    // Test reset button
-    await publicGatewayResetButton.click()
-
-    // Verify reset to default
-    await expect(publicGatewayElement).toHaveValue(DEFAULT_PATH_GATEWAY)
+    // Clear empties the field
+    await publicGatewayClearButton.click()
+    await expect(publicGatewayElement).toHaveValue('')
   })
 
   test('Submit Local Gateway and confirm it is applied', async ({ page }) => {
-    // custom-gw-test.localhost resolves to 127.0.0.1, so it reaches the real e2e
-    // kubo gateway (which serves the probe's inline-CID image). The distinctive
-    // hostname lets us confirm on the Status page that the override is in use.
+    // A distinctive hostname we can spot on the Status page to confirm the
+    // override is in use. It resolves to 127.0.0.1, so it still reaches the e2e
+    // kubo gateway for previews.
     const localGatewayUrl = `http://custom-gw-test.localhost:${process.env.IPFS_GATEWAY_PORT}`
     const input = page.locator('#local-gateway')
     const submitButton = page.locator('#local-gateway-submit-button')
@@ -137,7 +135,7 @@ test.describe('Settings screen', () => {
     await expect(input).toHaveClass(/focus-outline-green/, { timeout: 5000 })
     await expect(submitButton).toBeEnabled()
 
-    // submit runs the checkViaImgSrc probe against the real kubo gateway and saves
+    // submit saves the override (URL format is validated, no reachability probe)
     await submitButton.click()
 
     // saved: no pending changes, so submit goes back to disabled, value persists

--- a/test/e2e/settings.test.js
+++ b/test/e2e/settings.test.js
@@ -3,7 +3,7 @@ import { fileURLToPath } from 'url'
 import { dirname, join } from 'path'
 import { test, expect } from './setup/coverage.js'
 import { settings } from './setup/locators.js'
-import { TEST_PATH_GATEWAY, TEST_SUBDOMAIN_GATEWAY } from '../../src/bundles/gateway.js'
+import { DEFAULT_PATH_GATEWAY, DEFAULT_SUBDOMAIN_GATEWAY, TEST_PATH_GATEWAY, TEST_SUBDOMAIN_GATEWAY } from '../../src/bundles/gateway.js'
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = dirname(__filename)
@@ -41,8 +41,8 @@ test.describe('Settings screen', () => {
 
     await expect(publicSubdomainGatewayElement).toBeVisible()
 
-    // Empty by default; the user opts into a public gateway.
-    await expect(publicSubdomainGatewayElement).toHaveValue('')
+    // Prefilled with the default subdomain gateway; Clear opts out of it.
+    await expect(publicSubdomainGatewayElement).toHaveValue(DEFAULT_SUBDOMAIN_GATEWAY)
 
     // First, set an invalid value to verify red border appears
     await publicSubdomainGatewayElement.click({ clickCount: 3 })
@@ -82,8 +82,8 @@ test.describe('Settings screen', () => {
 
     await expect(publicGatewayElement).toBeVisible()
 
-    // Empty by default; the user opts into a public gateway.
-    await expect(publicGatewayElement).toHaveValue('')
+    // Prefilled with the default path gateway; Clear opts out of it.
+    await expect(publicGatewayElement).toHaveValue(DEFAULT_PATH_GATEWAY)
 
     // First, set an invalid value to verify red border appears
     await publicGatewayElement.click({ clickCount: 3 })

--- a/test/e2e/share-link.test.js
+++ b/test/e2e/share-link.test.js
@@ -43,9 +43,17 @@ test.describe.serial('Share Link types', () => {
     await ipfs.files.cp(`/ipfs/${CID}`, `/${FILENAME}`, { flush: true }).catch(() => {})
   })
 
-  test('default is a native ipfs:// URI (base32 CIDv1)', async ({ page }) => {
+  test('default is a subdomain link on dweb.link (DEFAULT_SUBDOMAIN_GATEWAY)', async ({ page }) => {
     await page.goto('/#/files')
     await applySettings(page, {})
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`https://${CID}.ipfs.dweb.link?filename=${FILENAME}`)
+  })
+
+  test('native type copies an ipfs:// URI (base32 CIDv1)', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, { type: 'native' })
     await page.reload()
     const input = await openShareLinkInput(page)
     await expect(input).toHaveValue(`ipfs://${CID}?filename=${FILENAME}`)
@@ -104,7 +112,7 @@ test.describe.serial('Share Link types', () => {
     await page.goto('/#/settings')
     await applySettings(page, {})
     await page.reload()
-    // Native is the default; pick the local path option and confirm it is stored.
+    // Pick the local path option and confirm it is stored.
     await page.getByText('Local gateway, path link', { exact: true }).click()
     await expect
       .poll(() => page.evaluate((k) => {

--- a/test/e2e/share-link.test.js
+++ b/test/e2e/share-link.test.js
@@ -1,0 +1,116 @@
+import { test, expect } from './setup/coverage.js'
+import { files, dismissImportNotification } from './setup/locators.js'
+import { create } from 'kubo-rpc-client'
+
+// "hello world" as an inline (identity-hash) raw CIDv1, so it resolves offline
+// and its base32 form is short enough for a subdomain label.
+const CID = 'bafkqac3imvwgy3zao5xxe3de'
+const FILENAME = 'share-link-e2e.txt'
+const KUBO_GATEWAY = `http://127.0.0.1:${process.env.IPFS_GATEWAY_PORT}`
+
+const SETTING_KEYS = {
+  type: 'ipfsShareLinkType',
+  localGateway: 'ipfsLocalGateway',
+  publicGateway: 'ipfsPublicGateway',
+  publicSubdomainGateway: 'ipfsPublicSubdomainGateway'
+}
+
+// These settings live in localStorage as plain strings and are read on init, so
+// set them, then reload for the gateway bundle to pick them up.
+const applySettings = async (page, settings) => {
+  await page.evaluate(({ map, s }) => {
+    Object.values(map).forEach((key) => window.localStorage.removeItem(key))
+    for (const prop of Object.keys(map)) {
+      if (s[prop] != null) window.localStorage.setItem(map[prop], s[prop])
+    }
+  }, { map: SETTING_KEYS, s: settings })
+}
+
+// Opens the Share modal for the seeded file and returns the readonly link input.
+const openShareLinkInput = async (page) => {
+  await dismissImportNotification(page)
+  const row = page.getByTestId('file-row').filter({ hasText: FILENAME })
+  await expect(row).toBeVisible({ timeout: 30000 })
+  await files.contextMenuButton(page, FILENAME).click()
+  await files.contextMenuItem(page, 'Share link').click()
+  return page.locator('div[role="dialog"] input[readonly]')
+}
+
+test.describe.serial('Share Link types', () => {
+  test.beforeEach(async () => {
+    // Seed a known file into MFS so a row is always present to share.
+    const ipfs = create(process.env.IPFS_RPC_ADDR)
+    await ipfs.files.cp(`/ipfs/${CID}`, `/${FILENAME}`, { flush: true }).catch(() => {})
+  })
+
+  test('default is a native ipfs:// URI (base32 CIDv1)', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, {})
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`ipfs://${CID}?filename=${FILENAME}`)
+  })
+
+  test('local path defaults to the Kubo config gateway', async ({ page }) => {
+    await page.goto('/#/')
+    await applySettings(page, { type: 'local-path' })
+    await page.reload()
+    // The Status page Advanced panel renders selectGatewayUrl: this both loads
+    // the Kubo config and confirms the default local gateway matches it.
+    const gatewayText = page.getByText(KUBO_GATEWAY, { exact: false })
+    if (!(await gatewayText.first().isVisible().catch(() => false))) {
+      await page.getByText('Advanced').click()
+    }
+    await expect(gatewayText.first()).toBeVisible({ timeout: 30000 })
+
+    await page.goto('/#/files')
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`${KUBO_GATEWAY}/ipfs/${CID}?filename=${FILENAME}`)
+  })
+
+  test('local path honors a custom-port override', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, { type: 'local-path', localGateway: 'http://127.0.0.1:9999' })
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`http://127.0.0.1:9999/ipfs/${CID}?filename=${FILENAME}`)
+  })
+
+  test('local subdomain uses localhost', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, { type: 'local-subdomain', localGateway: 'http://127.0.0.1:9999' })
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`http://${CID}.ipfs.localhost:9999?filename=${FILENAME}`)
+  })
+
+  test('public path uses the configured public path gateway', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, { type: 'public-path', publicGateway: 'https://path-gw.example.com' })
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`https://path-gw.example.com/ipfs/${CID}?filename=${FILENAME}`)
+  })
+
+  test('public subdomain uses the configured public subdomain gateway', async ({ page }) => {
+    await page.goto('/#/files')
+    await applySettings(page, { type: 'public-subdomain', publicSubdomainGateway: 'https://subdomain-gw.example.net' })
+    await page.reload()
+    const input = await openShareLinkInput(page)
+    await expect(input).toHaveValue(`https://${CID}.ipfs.subdomain-gw.example.net?filename=${FILENAME}`)
+  })
+
+  test('selecting a type in Settings persists the choice', async ({ page }) => {
+    await page.goto('/#/settings')
+    await applySettings(page, {})
+    await page.reload()
+    // Native is the default; pick the local path option and confirm it is stored.
+    await page.getByText('Local gateway, path link', { exact: true }).click()
+    await expect
+      .poll(() => page.evaluate((k) => {
+        const value = window.localStorage.getItem(k)
+        try { return JSON.parse(value) } catch { return value }
+      }, SETTING_KEYS.type))
+      .toBe('local-path')
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -72,6 +72,7 @@
     "src/lib/count-dirs.js",
     "src/lib/sort.js",
     "src/lib/files.js",
+    "src/lib/share-link.js",
     "src/lib/ipfs-path.js",
     "src/env.js",
     "src/lib/hofs/**/*.js",


### PR DESCRIPTION
## Problem

Share Link always built a URL on a third-party public gateway (dweb.link, with ipfs.io fallback) and Publish to IPNS hardcoded the public path gateway. There was no way to copy a native `ipfs://` address, opt out of public gateways, or get a link pointing at your own node for other apps on the same machine (ipfs/ipfs-desktop#2500). The webui also probed gateways with image loads on startup and in Settings.

## Fix

- Settings gains a "Sharing IPFS Links" section used by both Share Link and Publish to IPNS: native `ipfs://` addresses, local gateway links, or public gateway links (path or subdomain)
- defaults are unchanged: `ipfs.io` and `dweb.link` stay prefilled and share links are built on `dweb.link` as before; flipping the default to native URIs is a follow-up where `DEFAULT_SHARE_LINK_TYPE` and the `DEFAULT_*_GATEWAY` constants are the only knobs
- clearing a public gateway in Settings now opts out of it entirely; a link type whose gateway is missing falls back to a native address, so copied links are never empty or broken
- Share modal offers a local HTTP link checkbox, with optional localhost subdomains for web apps that need origin isolation; links labeled local draw from the local gateway only, never a public fallback
- gateway reachability probes removed; URL format is validated and the user's choice trusted

This is part of wider URI support to move away from copying public gateway links by default:

- ipfs/kubo#11375
- ipfs/ipfs-companion#1371

## Demo

New "Sharing IPFS Links" section on the Settings screen:

> <img width="2250" height="1442" alt="2026-07-16_21-01" src="https://github.com/user-attachments/assets/a21ac100-5c7f-41b0-9948-b22f76af6f1a" />

The Share modal looks the same as before, with a new opt-in checkbox for a local link:

> <img width="773" height="646" alt="1_2026-03-10_18-00" src="https://github.com/user-attachments/assets/10d0c971-3a3b-40db-9efe-4b9c6a52954b" />

Once clicked, we update UI to indicate this is no longer for sharing with friends, and only other apps on the same machine. We use IP-based Path gateway that is known to work everywhere:

> <img width="777" height="408" alt="2_2026-03-10_18-00" src="https://github.com/user-attachments/assets/46aba3d3-bd73-4291-8194-1d5adb569319" />

Subdomain gateways do not work on all platforms, and only benefit web contexts (browser web apps, websites with relative paths etc), so are opt-in:

> <img width="778" height="404" alt="3_2026-03-10_18-00" src="https://github.com/user-attachments/assets/e29cf2b5-d54c-4f43-9394-62b83edbed3e" />