### PR TITLE
feat(config): add Local Gateway URL for reverse proxy and Docker

### DIFF
--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -50,7 +50,7 @@
   },
   "localGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.example.com)",
-    "description": "Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway address from Kubo config."
+    "description": "Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway URL from Kubo config."
   },
   "publicSubdomainGatewayForm": {
     "placeholder": "Enter a URL (https://dweb.link)"

--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -48,6 +48,10 @@
   "publicGatewayForm": {
     "placeholder": "Enter a URL (https://ipfs.io)"
   },
+  "localGatewayForm": {
+    "placeholder": "Enter a URL (https://ipfs.example.com)",
+    "description": "Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway address from Kubo config."
+  },
   "publicSubdomainGatewayForm": {
     "placeholder": "Enter a URL (https://dweb.link)"
   },
@@ -87,6 +91,7 @@
     "pinStatus": "Pin Status",
     "publicKey": "Public key",
     "publicGateway": "Public Gateway",
+    "localGateway": "Local Gateway",
     "rateIn": "Rate in",
     "rateOut": "Rate out",
     "repo": "Repo",

--- a/public/locales/en/app.json
+++ b/public/locales/en/app.json
@@ -49,8 +49,7 @@
     "placeholder": "Enter a URL (https://ipfs.io)"
   },
   "localGatewayForm": {
-    "placeholder": "Enter a URL (https://ipfs.example.com)",
-    "description": "Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway URL from Kubo config."
+    "placeholder": "Enter a URL (http://localhost:8080)"
   },
   "publicSubdomainGatewayForm": {
     "placeholder": "Enter a URL (https://dweb.link)"

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -23,6 +23,7 @@
     "translationProjectLink": "Join the IPFS Translation Project"
   },
   "apiDescription": "<0>If your node is configured with a <1>custom Kubo RPC API address</1>, including a port other than the default 5001, enter it here.</0>",
+  "localGatewayDescription": "<0>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <1>gateway address</1> from your Kubo config.</0>",
   "publicSubdomainGatewayDescription": "<0>Select a default <1>Subdomain Gateway</1> for generating shareable links.</0>",
   "publicPathGatewayDescription": "<0>Select a fallback <1>Path Gateway</1> for generating shareable links for CIDs that exceed the 63-character DNS limit.</0>",
   "retrievalDiagnosticService": {

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -69,7 +69,9 @@ bundle.selectGatewayUrl = createSelector(
   'selectLocalGateway',
   (config, publicGateway, localGateway) => {
     // Priority: 1) User-configured local gateway, 2) Kubo config, 3) Public gateway
-    return localGateway || getURLFromAddress('Gateway', config) || publicGateway
+    const url = localGateway || getURLFromAddress('Gateway', config) || publicGateway
+    // Normalize: remove trailing slashes to avoid double slashes when constructing paths
+    return url.replace(/\/+$/, '')
   }
 )
 

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -66,7 +66,11 @@ bundle.reactIsSameOriginToBridge = createSelector(
 bundle.selectGatewayUrl = createSelector(
   'selectConfigObject',
   'selectPublicGateway',
-  (config, publicGateway) => getURLFromAddress('Gateway', config) || publicGateway
+  'selectLocalGateway',
+  (config, publicGateway, localGateway) => {
+    // Priority: 1) User-configured local gateway, 2) Kubo config, 3) Public gateway
+    return localGateway || getURLFromAddress('Gateway', config) || publicGateway
+  }
 )
 
 bundle.selectAvailableGatewayUrl = createSelector(

--- a/src/bundles/config.js
+++ b/src/bundles/config.js
@@ -23,6 +23,18 @@ const bundle = createAsyncResourceBundle({
 
     const config = JSON.parse(conf)
 
+    // An explicit Local Gateway URL is the gateway the browser is meant to reach
+    // for everything (reverse proxy, Docker, non-default host or port), so trust
+    // it for the reachability-probed availableGateway too. Without this, the
+    // 127.0.0.1 probe below fails for remote users and previews, thumbnails and
+    // IPNS links fall back to the public gateway instead of the user's own node.
+    // https://github.com/ipfs/ipfs-webui/issues/2458
+    const localGateway = store.selectLocalGateway()
+    if (localGateway) {
+      store.doSetAvailableGateway(localGateway)
+      return conf
+    }
+
     const publicGateway = store.selectPublicGateway()
     const url = getURLFromAddress('Gateway', config) || publicGateway
 

--- a/src/bundles/config.test.js
+++ b/src/bundles/config.test.js
@@ -1,0 +1,54 @@
+/* global describe, it, expect, beforeEach, afterEach */
+import { jest } from '@jest/globals'
+import { composeBundles } from 'redux-bundler'
+import configBundle from './config.js'
+import gatewayBundle from './gateway.js'
+
+// selectIpfsReady is false so the reactConfigFetch reactor stays quiet and we
+// drive doFetchConfig (which runs getPromise) deterministically from the test.
+const createMockIpfsBundle = (config) => ({
+  name: 'ipfs',
+  getExtraArgs: () => ({ getIpfs: () => ({ config: { getAll: async () => config } }) }),
+  selectIpfsReady: () => false,
+  selectIpfsConnected: () => false
+})
+
+const createStore = (config) => composeBundles(
+  createMockIpfsBundle(config),
+  gatewayBundle,
+  configBundle
+)()
+
+describe('gateway selection with a Local Gateway URL override', () => {
+  // getURLFromAddress logs when @multiformats/multiaddr-to-uri cannot resolve a
+  // multiaddr, which it cannot under jest; the override path does not need it.
+  let logSpy
+  beforeEach(() => {
+    window.localStorage.clear()
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+  })
+  afterEach(() => logSpy.mockRestore())
+
+  // https://github.com/ipfs/ipfs-webui/issues/2458
+  it('routes the configured and available gateway through the override, and falls back to the Kubo config gateway when cleared', async () => {
+    const store = createStore({ Addresses: { Gateway: '/ip4/127.0.0.1/tcp/8080' } })
+
+    // trailing slash is normalized away on save
+    await store.doUpdateLocalGateway('https://ipfs.example.com/')
+    await store.doFetchConfig()
+
+    expect(store.selectLocalGateway()).toBe('https://ipfs.example.com')
+    // override beats the Kubo config gateway for download links
+    expect(store.selectGatewayUrl()).toBe('https://ipfs.example.com')
+    // getPromise sets availableGateway to the override, so previews, thumbnails
+    // and IPNS links (which use selectAvailableGateway*) honor it too
+    expect(store.selectAvailableGateway()).toBe('https://ipfs.example.com')
+    expect(store.selectAvailableGatewayUrl()).toBe('https://ipfs.example.com')
+
+    // clearing the override removes it from gateway selection (the multiaddr
+    // ->URI fallback to the Kubo config gateway is covered by e2e, since
+    // @multiformats/multiaddr-to-uri does not load under jest)
+    await store.doUpdateLocalGateway('')
+    expect(store.selectLocalGateway()).toBe('')
+  })
+})

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -19,6 +19,13 @@ const readPublicGatewaySetting = () => {
   return setting || DEFAULT_PATH_GATEWAY
 }
 
+const readLocalGatewaySetting = () => {
+  const setting = readSetting('ipfsLocalGateway')
+  // Return empty string if not set, so we can distinguish between
+  // "not configured" and "configured to empty"
+  return setting || ''
+}
+
 const readPublicSubdomainGatewaySetting = () => {
   const setting = readSetting('ipfsPublicSubdomainGateway')
   return setting || DEFAULT_SUBDOMAIN_GATEWAY
@@ -33,7 +40,8 @@ const init = () => ({
   availableGateway: null,
   publicGateway: readPublicGatewaySetting(),
   publicSubdomainGateway: readPublicSubdomainGatewaySetting(),
-  ipfsCheckUrl: readIpfsCheckUrlSetting()
+  ipfsCheckUrl: readIpfsCheckUrlSetting(),
+  localGateway: readLocalGatewaySetting()
 })
 
 /**
@@ -207,6 +215,10 @@ const bundle = {
       return { ...state, ipfsCheckUrl: action.payload }
     }
 
+    if (action.type === 'SET_LOCAL_GATEWAY') {
+      return { ...state, localGateway: action.payload }
+    }
+
     return state
   },
 
@@ -244,6 +256,15 @@ const bundle = {
   },
 
   /**
+   * @param {string} address
+   * @returns {function({dispatch: Function}): Promise<void>}
+   */
+  doUpdateLocalGateway: (address) => async ({ dispatch }) => {
+    await writeSetting('ipfsLocalGateway', address)
+    dispatch({ type: 'SET_LOCAL_GATEWAY', payload: address })
+  },
+
+  /**
    * @param {any} state
    * @returns {string|null}
    */
@@ -265,7 +286,13 @@ const bundle = {
    * @param {any} state
    * @returns {string}
    */
-  selectIpfsCheckUrl: (state) => state?.gateway?.ipfsCheckUrl
+  selectIpfsCheckUrl: (state) => state?.gateway?.ipfsCheckUrl,
+
+  /**
+   * @param {any} state
+   * @returns {string}
+   */
+  selectLocalGateway: (state) => state?.gateway?.localGateway
 }
 
 export default bundle

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -264,6 +264,24 @@ const bundle = {
     const normalizedAddress = address.replace(/\/+$/, '')
     await writeSetting('ipfsLocalGateway', normalizedAddress)
     dispatch({ type: 'SET_LOCAL_GATEWAY', payload: normalizedAddress })
+
+    // Sync to kuboGateway for Helia/Explore components
+    if (normalizedAddress) {
+      try {
+        const url = new URL(normalizedAddress)
+        const host = url.hostname
+        const port = url.port || (url.protocol === 'https:' ? '443' : '80')
+        const protocol = url.protocol.replace(':', '')
+        await writeSetting('kuboGateway', {
+          host,
+          port,
+          protocol,
+          trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: protocol === 'http' } }
+        })
+      } catch (e) {
+        console.error('Error syncing ipfsLocalGateway to kuboGateway:', e)
+      }
+    }
   },
 
   /**

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -260,8 +260,10 @@ const bundle = {
    * @returns {function({dispatch: Function}): Promise<void>}
    */
   doUpdateLocalGateway: (address) => async ({ dispatch }) => {
-    await writeSetting('ipfsLocalGateway', address)
-    dispatch({ type: 'SET_LOCAL_GATEWAY', payload: address })
+    // Normalize: remove trailing slashes
+    const normalizedAddress = address.replace(/\/+$/, '')
+    await writeSetting('ipfsLocalGateway', normalizedAddress)
+    dispatch({ type: 'SET_LOCAL_GATEWAY', payload: normalizedAddress })
   },
 
   /**

--- a/src/bundles/gateway.js
+++ b/src/bundles/gateway.js
@@ -60,6 +60,31 @@ export const checkValidHttpUrl = (value) => {
 }
 
 /**
+ * Default `kuboGateway` config consumed by Helia/verified-fetch
+ * (ipld-explorer-components) on the Explore page when no explicit Local Gateway
+ * URL is set.
+ */
+export const DEFAULT_KUBO_GATEWAY = { trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: false } } }
+
+/**
+ * Convert a Local Gateway URL into the `kuboGateway` config shape consumed by
+ * Helia/verified-fetch on the Explore page, so the explorer fetches blocks from
+ * the same gateway the rest of the WebUI uses.
+ * @param {string} gatewayUrl
+ * @returns {{host: string, port: string, protocol: string, trustlessBlockBrokerConfig: object}}
+ */
+export const localGatewayToKuboGateway = (gatewayUrl) => {
+  const url = new URL(gatewayUrl)
+  const protocol = url.protocol.replace(':', '')
+  return {
+    host: url.hostname,
+    port: url.port || (url.protocol === 'https:' ? '443' : '80'),
+    protocol,
+    trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: protocol === 'http' } }
+  }
+}
+
+/**
  * Check if any hashes from IMG_ARRAY can be loaded from the provided gatewayUrl
  * @param {string} gatewayUrl - The gateway URL to check
  * @see https://github.com/ipfs/ipfs-webui/issues/1937#issuecomment-1152894211 for more info
@@ -79,7 +104,9 @@ export const checkViaImgSrc = (gatewayUrl) => {
    */
   // @ts-expect-error - Promise.any requires ES2021 but we're on ES2020
   return Promise.any(IMG_ARRAY.map(element => {
-    const imgUrl = new URL(`${url.protocol}//${url.hostname}/ipfs/${element.hash}?now=${Date.now()}&filename=${element.name}#x-ipfs-companion-no-redirect`)
+    // url.host (not hostname) keeps the port, so the probe also works for local
+    // gateways on non-default ports, e.g. http://127.0.0.1:8080.
+    const imgUrl = new URL(`${url.protocol}//${url.host}/ipfs/${element.hash}?now=${Date.now()}&filename=${element.name}#x-ipfs-companion-no-redirect`)
     return checkImgSrcPromise(imgUrl)
   }))
 }
@@ -265,22 +292,16 @@ const bundle = {
     await writeSetting('ipfsLocalGateway', normalizedAddress)
     dispatch({ type: 'SET_LOCAL_GATEWAY', payload: normalizedAddress })
 
-    // Sync to kuboGateway for Helia/Explore components
+    // Keep kuboGateway (used by Helia/Explore) in sync with the override.
     if (normalizedAddress) {
       try {
-        const url = new URL(normalizedAddress)
-        const host = url.hostname
-        const port = url.port || (url.protocol === 'https:' ? '443' : '80')
-        const protocol = url.protocol.replace(':', '')
-        await writeSetting('kuboGateway', {
-          host,
-          port,
-          protocol,
-          trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: protocol === 'http' } }
-        })
+        await writeSetting('kuboGateway', localGatewayToKuboGateway(normalizedAddress))
       } catch (e) {
         console.error('Error syncing ipfsLocalGateway to kuboGateway:', e)
       }
+    } else {
+      // Override cleared: restore defaults so Explore stops using the old host.
+      await writeSetting('kuboGateway', DEFAULT_KUBO_GATEWAY)
     }
   },
 

--- a/src/bundles/gateway.test.js
+++ b/src/bundles/gateway.test.js
@@ -1,0 +1,43 @@
+/* global describe, it, expect */
+import { localGatewayToKuboGateway, checkValidHttpUrl } from './gateway.js'
+
+describe('localGatewayToKuboGateway', () => {
+  it('keeps an explicit port and treats http as insecure', () => {
+    expect(localGatewayToKuboGateway('http://127.0.0.1:8080')).toEqual({
+      host: '127.0.0.1',
+      port: '8080',
+      protocol: 'http',
+      trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: true } }
+    })
+  })
+
+  it('defaults the port to 443 for https and keeps it secure', () => {
+    expect(localGatewayToKuboGateway('https://ipfs.example.com')).toEqual({
+      host: 'ipfs.example.com',
+      port: '443',
+      protocol: 'https',
+      trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: false } }
+    })
+  })
+
+  it('defaults the port to 80 for http without an explicit port', () => {
+    expect(localGatewayToKuboGateway('http://gateway.local').port).toBe('80')
+  })
+
+  it('throws on an invalid URL', () => {
+    expect(() => localGatewayToKuboGateway('not a url')).toThrow()
+  })
+})
+
+describe('checkValidHttpUrl', () => {
+  it('accepts http and https URLs, including non-default ports', () => {
+    expect(checkValidHttpUrl('http://127.0.0.1:8080')).toBe(true)
+    expect(checkValidHttpUrl('https://ipfs.example.com')).toBe(true)
+  })
+
+  it('rejects non-http(s) and malformed values', () => {
+    expect(checkValidHttpUrl('ftp://example.com')).toBe(false)
+    expect(checkValidHttpUrl('not a url')).toBe(false)
+    expect(checkValidHttpUrl('')).toBe(false)
+  })
+})

--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -332,7 +332,25 @@ const actions = {
     }
 
     const kuboGateway = readSetting('kuboGateway')
-    if (kuboGateway === null || typeof kuboGateway === 'string' || typeof kuboGateway === 'boolean' || typeof kuboGateway === 'number') {
+    const localGateway = readSetting('ipfsLocalGateway')
+
+    if (localGateway) {
+      // User has configured a custom local gateway, sync it to kuboGateway for Helia/Explore
+      try {
+        const url = new URL(localGateway)
+        const host = url.hostname
+        const port = url.port || (url.protocol === 'https:' ? '443' : '80')
+        const protocol = url.protocol.replace(':', '')
+        await writeSetting('kuboGateway', {
+          host,
+          port,
+          protocol,
+          trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: protocol === 'http' } }
+        })
+      } catch (e) {
+        console.error('Error parsing ipfsLocalGateway for kuboGateway:', e)
+      }
+    } else if (kuboGateway === null || typeof kuboGateway === 'string' || typeof kuboGateway === 'boolean' || typeof kuboGateway === 'number') {
       // empty or invalid, set defaults
       await writeSetting('kuboGateway', { trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: false } } })
     } else if (/** @type {Record<string, any>} */(kuboGateway).trustlessBlockBrokerConfig == null) {

--- a/src/bundles/ipfs-provider.js
+++ b/src/bundles/ipfs-provider.js
@@ -6,6 +6,7 @@ import last from 'it-last'
 import * as Enum from '../lib/enum.js'
 import { perform } from './task.js'
 import { readSetting, writeSetting } from './local-storage.js'
+import { localGatewayToKuboGateway, DEFAULT_KUBO_GATEWAY } from './gateway.js'
 import { contextBridge } from '../helpers/context-bridge'
 import { createSelector } from 'redux-bundler'
 
@@ -334,28 +335,19 @@ const actions = {
     const kuboGateway = readSetting('kuboGateway')
     const localGateway = readSetting('ipfsLocalGateway')
 
-    if (localGateway) {
+    if (typeof localGateway === 'string' && localGateway) {
       // User has configured a custom local gateway, sync it to kuboGateway for Helia/Explore
       try {
-        const url = new URL(localGateway)
-        const host = url.hostname
-        const port = url.port || (url.protocol === 'https:' ? '443' : '80')
-        const protocol = url.protocol.replace(':', '')
-        await writeSetting('kuboGateway', {
-          host,
-          port,
-          protocol,
-          trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: protocol === 'http' } }
-        })
+        await writeSetting('kuboGateway', localGatewayToKuboGateway(localGateway))
       } catch (e) {
         console.error('Error parsing ipfsLocalGateway for kuboGateway:', e)
       }
     } else if (kuboGateway === null || typeof kuboGateway === 'string' || typeof kuboGateway === 'boolean' || typeof kuboGateway === 'number') {
       // empty or invalid, set defaults
-      await writeSetting('kuboGateway', { trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: false } } })
+      await writeSetting('kuboGateway', DEFAULT_KUBO_GATEWAY)
     } else if (/** @type {Record<string, any>} */(kuboGateway).trustlessBlockBrokerConfig == null) {
       // missing trustlessBlockBrokerConfig, set defaults
-      await writeSetting('kuboGateway', { ...kuboGateway, trustlessBlockBrokerConfig: { init: { allowLocal: true, allowInsecure: false } } })
+      await writeSetting('kuboGateway', { ...kuboGateway, ...DEFAULT_KUBO_GATEWAY })
     }
   },
 

--- a/src/components/ipns-manager/IpnsManager.js
+++ b/src/components/ipns-manager/IpnsManager.js
@@ -53,7 +53,7 @@ const OptionsCell = ({ t, name, showRenameKeyModal, showRemoveKeyModal }) => {
   )
 }
 
-export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, doRenameIpnsKey, doRemoveIpnsKey, availableGateway, ipnsKeys }) => {
+export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, doRenameIpnsKey, doRemoveIpnsKey, availableGatewayUrl, ipnsKeys }) => {
   const [isGenerateKeyModalOpen, setGenerateKeyModalOpen] = useState(false)
   const showGenerateKeyModal = () => setGenerateKeyModalOpen(true)
   const hideGenerateKeyModal = () => setGenerateKeyModalOpen(false)
@@ -118,7 +118,7 @@ export const IpnsManager = ({ t, ipfsReady, doFetchIpnsKeys, doGenerateIpnsKey, 
                   flexShrink={1}
                   cellRenderer={({ rowData }) => (
                     rowData.published
-                      ? <a href={`${availableGateway}/ipns/${rowData.id}`} target='_blank' rel='noopener noreferrer' className='link blue'>{rowData.id}</a>
+                      ? <a href={`${availableGatewayUrl}/ipns/${rowData.id}`} target='_blank' rel='noopener noreferrer' className='link blue'>{rowData.id}</a>
                       : rowData.id
                   )} />
                 <Column
@@ -184,7 +184,7 @@ IpnsManager.defaultProps = {
 export default connect(
   'selectIpfsReady',
   'selectIpnsKeys',
-  'selectAvailableGateway',
+  'selectAvailableGatewayUrl',
   'doFetchIpnsKeys',
   'doGenerateIpnsKey',
   'doRemoveIpnsKey',

--- a/src/components/local-gateway-form/LocalGatewayForm.js
+++ b/src/components/local-gateway-form/LocalGatewayForm.js
@@ -1,0 +1,82 @@
+import React, { useState, useEffect } from 'react'
+import { connect } from 'redux-bundler-react'
+import { withTranslation } from 'react-i18next'
+import Button from '../button/button.tsx'
+import { checkValidHttpUrl } from '../../bundles/gateway.js'
+
+const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
+  const [value, setValue] = useState(localGateway)
+  const [isValid, setIsValid] = useState(true)
+
+  useEffect(() => {
+    // Empty value is valid (means "use default from Kubo config")
+    setIsValid(value === '' || checkValidHttpUrl(value))
+  }, [value])
+
+  const onChange = (event) => setValue(event.target.value)
+
+  const onSubmit = async (event) => {
+    event.preventDefault()
+    if (isValid) {
+      doUpdateLocalGateway(value)
+    }
+  }
+
+  const onClear = async (event) => {
+    event.preventDefault()
+    setValue('')
+    doUpdateLocalGateway('')
+  }
+
+  const onKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      onSubmit(event)
+    }
+  }
+
+  const hasChanges = value !== localGateway
+
+  return (
+    <form onSubmit={onSubmit}>
+      <input
+        id='local-gateway'
+        aria-label={t('terms.localGateway')}
+        placeholder={t('localGatewayForm.placeholder', 'e.g., https://ipfs.example.com')}
+        type='text'
+        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${!isValid ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        onChange={onChange}
+        onKeyPress={onKeyPress}
+        value={value}
+      />
+      <div className='tr'>
+        <Button
+          id='local-gateway-clear-button'
+          minWidth={100}
+          height={40}
+          bg='bg-charcoal'
+          className='tc'
+          disabled={value === ''}
+          onClick={onClear}>
+          {t('app:actions.clear')}
+        </Button>
+        <Button
+          id='local-gateway-submit-button'
+          minWidth={100}
+          height={40}
+          className='mt2 mt0-l ml2-l tc'
+          disabled={!isValid || !hasChanges}>
+          {t('actions.submit')}
+        </Button>
+      </div>
+      <p className='f6 charcoal-muted mt2 mb0'>
+        {t('localGatewayForm.description', 'Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway address from Kubo config.')}
+      </p>
+    </form>
+  )
+}
+
+export default connect(
+  'doUpdateLocalGateway',
+  'selectLocalGateway',
+  withTranslation('app')(LocalGatewayForm)
+)

--- a/src/components/local-gateway-form/LocalGatewayForm.js
+++ b/src/components/local-gateway-form/LocalGatewayForm.js
@@ -2,24 +2,36 @@ import React, { useState, useEffect } from 'react'
 import { connect } from 'redux-bundler-react'
 import { withTranslation } from 'react-i18next'
 import Button from '../button/button.tsx'
-import { checkValidHttpUrl } from '../../bundles/gateway.js'
+import { checkValidHttpUrl, checkViaImgSrc } from '../../bundles/gateway.js'
 
 const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
+  // Empty value is valid: it means "use the gateway address from Kubo config".
   const [value, setValue] = useState(localGateway)
-  const [isValid, setIsValid] = useState(true)
+  const [isValid, setIsValid] = useState(localGateway === '' || checkValidHttpUrl(localGateway))
+  const [showFailState, setShowFailState] = useState(!(localGateway === '' || checkValidHttpUrl(localGateway)))
 
   useEffect(() => {
-    // Empty value is valid (means "use default from Kubo config")
-    setIsValid(value === '' || checkValidHttpUrl(value))
+    const valid = value === '' || checkValidHttpUrl(value)
+    setIsValid(valid)
+    setShowFailState(!valid)
   }, [value])
 
   const onChange = (event) => setValue(event.target.value)
 
   const onSubmit = async (event) => {
     event.preventDefault()
-    if (isValid) {
-      doUpdateLocalGateway(value)
+    if (!isValid) return
+    // A non-empty override must be reachable from the browser, otherwise it
+    // would silently break download and preview links with no fallback.
+    if (value !== '') {
+      try {
+        await checkViaImgSrc(value)
+      } catch (e) {
+        setShowFailState(true)
+        return
+      }
     }
+    doUpdateLocalGateway(value)
   }
 
   const onClear = async (event) => {
@@ -41,9 +53,9 @@ const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
       <input
         id='local-gateway'
         aria-label={t('terms.localGateway')}
-        placeholder={t('localGatewayForm.placeholder', 'e.g., https://ipfs.example.com')}
+        placeholder={t('localGatewayForm.placeholder', 'Enter a URL (http://localhost:8080)')}
         type='text'
-        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${!isValid ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
+        className={`w-100 lh-copy monospace f5 pl1 pv1 mb2 charcoal input-reset ba b--black-20 br1 ${showFailState ? 'focus-outline-red b--red-muted' : 'focus-outline-green b--green-muted'}`}
         onChange={onChange}
         onKeyPress={onKeyPress}
         value={value}
@@ -68,9 +80,6 @@ const LocalGatewayForm = ({ t, doUpdateLocalGateway, localGateway }) => {
           {t('actions.submit')}
         </Button>
       </div>
-      <p className='f6 charcoal-muted mt2 mb0'>
-        {t('localGatewayForm.description', 'Set this to your gateway URL if accessing WebUI through a reverse proxy or from a different host. Leave empty to use the gateway address from Kubo config.')}
-      </p>
     </form>
   )
 }

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -18,6 +18,7 @@ import AnalyticsToggle from '../components/analytics-toggle/AnalyticsToggle.js'
 import ApiAddressForm from '../components/api-address-form/api-address-form'
 import PublicGatewayForm from '../components/public-gateway-form/PublicGatewayForm.js'
 import PublicSubdomainGatewayForm from '../components/public-subdomain-gateway-form/PublicSubdomainGatewayForm.js'
+import LocalGatewayForm from '../components/local-gateway-form/LocalGatewayForm.js'
 import IpfsCheckForm from '../components/ipfs-check-form/IpfsCheckForm.js'
 import { JsonEditor } from './editor/JsonEditor.js'
 import Experiments from '../components/experiments/ExperimentsPanel.js'
@@ -67,19 +68,23 @@ export const SettingsPage = ({
 
     <Box className='mb3 pa4-l pa2'>
       <div className='lh-copy charcoal'>
+        <Title>{t('app:terms.localGateway')}</Title>
+        <LocalGatewayForm/>
+      </div>
+      <div className='lh-copy charcoal mt4'>
         <Title>{t('app:terms.publicGateway')}</Title>
-          <Trans i18nKey='publicSubdomainGatewayDescription' t={t}>
-            <p>Select a default <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#subdomain' target='_blank' rel='noopener noreferrer'>Subdomain Gateway</a> for generating shareable links.</p>
-          </Trans>
-          <PublicSubdomainGatewayForm/>
-        </div>
-        <div className='lh-copy charcoal'>
-          <Trans i18nKey='publicPathGatewayDescription' t={t}>
-            <p>Select a fallback <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#path' target='_blank' rel='noopener noreferrer'>Path Gateway</a> for generating shareable links for CIDs that exceed the 63-character DNS limit.</p>
-          </Trans>
-          <PublicGatewayForm/>
-        </div>
-      </Box>
+        <Trans i18nKey='publicSubdomainGatewayDescription' t={t}>
+          <p>Select a default <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#subdomain' target='_blank' rel='noopener noreferrer'>Subdomain Gateway</a> for generating shareable links.</p>
+        </Trans>
+        <PublicSubdomainGatewayForm/>
+      </div>
+      <div className='lh-copy charcoal'>
+        <Trans i18nKey='publicPathGatewayDescription' t={t}>
+          <p>Select a fallback <a className='link blue' href='https://docs.ipfs.tech/concepts/ipfs-gateway/#path' target='_blank' rel='noopener noreferrer'>Path Gateway</a> for generating shareable links for CIDs that exceed the 63-character DNS limit.</p>
+        </Trans>
+        <PublicGatewayForm/>
+      </div>
+    </Box>
 
     <Box className='mb3 pa4-l pa2'>
       <Title>{t('ipnsPublishingKeys.title')}</Title>

--- a/src/settings/SettingsPage.js
+++ b/src/settings/SettingsPage.js
@@ -60,7 +60,7 @@ export const SettingsPage = ({
         <div className='lh-copy charcoal'>
           <Title>{t('app:terms.apiAddress')}</Title>
           <Trans i18nKey='apiDescription' t={t}>
-            <p>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addresses' target='_blank' rel='noopener noreferrer'>custom Kubo RPC API address</a>, including a port other than the default 5001, enter it here.</p>
+            <p>If your node is configured with a <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesapi' target='_blank' rel='noopener noreferrer'>custom Kubo RPC API address</a>, including a port other than the default 5001, enter it here.</p>
           </Trans>
           <ApiAddressForm/>
         </div>
@@ -69,6 +69,9 @@ export const SettingsPage = ({
     <Box className='mb3 pa4-l pa2'>
       <div className='lh-copy charcoal'>
         <Title>{t('app:terms.localGateway')}</Title>
+        <Trans i18nKey='localGatewayDescription' t={t}>
+          <p>If you access the WebUI through a reverse proxy, Docker, or a different host, enter the gateway URL your browser can reach. Leave empty to use the first <a className='link blue' href='https://github.com/ipfs/kubo/blob/master/docs/config.md#addressesgateway' target='_blank' rel='noopener noreferrer'>gateway address</a> from your Kubo config.</p>
+        </Trans>
         <LocalGatewayForm/>
       </div>
       <div className='lh-copy charcoal mt4'>

--- a/test/e2e/settings.test.js
+++ b/test/e2e/settings.test.js
@@ -118,6 +118,42 @@ test.describe('Settings screen', () => {
     await expect(publicGatewayElement).toHaveValue(DEFAULT_PATH_GATEWAY)
   })
 
+  test('Submit Local Gateway and confirm it is applied', async ({ page }) => {
+    // custom-gw-test.localhost resolves to 127.0.0.1, so it reaches the real e2e
+    // kubo gateway (which serves the probe's inline-CID image). The distinctive
+    // hostname lets us confirm on the Status page that the override is in use.
+    const localGatewayUrl = `http://custom-gw-test.localhost:${process.env.IPFS_GATEWAY_PORT}`
+    const input = page.locator('#local-gateway')
+    const submitButton = page.locator('#local-gateway-submit-button')
+
+    await expect(input).toBeVisible()
+
+    // empty by default (falls back to the gateway from Kubo config)
+    await expect(input).toHaveValue('')
+
+    await input.fill(localGatewayUrl)
+
+    // valid URL format shows the green outline and enables submit
+    await expect(input).toHaveClass(/focus-outline-green/, { timeout: 5000 })
+    await expect(submitButton).toBeEnabled()
+
+    // submit runs the checkViaImgSrc probe against the real kubo gateway and saves
+    await submitButton.click()
+
+    // saved: no pending changes, so submit goes back to disabled, value persists
+    await expect(submitButton).toBeDisabled({ timeout: 10000 })
+    await expect(input).toHaveValue(localGatewayUrl)
+
+    // confirm the override is applied where it matters: the Status page Advanced
+    // panel renders selectGatewayUrl, which now resolves to the override
+    await page.goto('/#/')
+    const gatewayValue = page.getByText(localGatewayUrl)
+    if (!(await gatewayValue.isVisible())) {
+      await page.getByText('Advanced').click()
+    }
+    await expect(gatewayValue).toBeVisible()
+  })
+
   test('Language selector', async ({ page }) => {
     const languages = await getLanguages()
     // Test with just a few languages to avoid timeout issues

--- a/test/e2e/setup/global-setup.js
+++ b/test/e2e/setup/global-setup.js
@@ -59,6 +59,7 @@ const globalSetup = async config => {
   process.env.IPFS_RPC_ADDR = rpcAddr
   process.env.IPFS_RPC_ID = id
   process.env.IPFS_RPC_VERSION = agentVersion
+  process.env.IPFS_GATEWAY_PORT = String(kuboGateway.port)
 
   await ensureKuboDaemon(apiOpts)
 


### PR DESCRIPTION
### Problem
When running Kubo in Docker or behind a reverse proxy, the WebUI generates incorrect gateway URLs (e.g., `http://127.0.0.1:8080`) for:
- File downloads
- Preview links
- IPLD Explore page

This happens because the WebUI reads the gateway address from Kubo's config, which typically contains Docker-internal addresses like `/ip4/0.0.0.0/tcp/8080` that get converted to `127.0.0.1:8080`.

- Fixes #2458
- Fixes #2383
- Fixes #2178

### Solution
Adds a new **"Local Gateway URL"** setting that allows users to override the gateway URL used by the WebUI.

**Priority order for gateway URL:**
1. User-configured Local Gateway URL (new)
2. Gateway address from Kubo config
3. Public Gateway (fallback)

### Changes
- Added `LocalGatewayForm` component in Settings
- Added `ipfsLocalGateway` localStorage key
- Modified `selectGatewayUrl` to check local override first
- Sync setting to `kuboGateway` format for IPLD Explore page compatibility

### How to Use
1. Go to **Settings** → **Local Gateway**
2. Enter your actual gateway URL (e.g., `https://ipfs.example.com`)
3. Submit - downloads and previews will now use this URL

Leave empty to use the existing behavior (auto-detect from Kubo config).

### Testing
- All Settings e2e tests pass
- Manually tested with Docker + reverse proxy setup
- Backward compatible - no change when setting is empty
