### PR TITLE
fix(files): unpin option missing in batch delete

### DIFF
--- a/src/files/FilesPage.js
+++ b/src/files/FilesPage.js
@@ -32,7 +32,7 @@ const FilesPage = ({
   doFetchPinningServices, doFilesFetch, doPinsFetch, doFilesSizeGet, doFilesDownloadLink, doFilesDownloadCarLink, doFilesWrite, doAddCarFile, doFilesBulkCidImport, doFilesAddPath, doUpdateHash,
   doFilesUpdateSorting, doFilesNavigateTo, doFilesMove, doSetCliOptions, doFetchRemotePins, remotePins, pendingPins, failedPins,
   ipfsProvider, ipfsConnected, doFilesMakeDir, doFilesShareLink, doFilesCidProvide, doFilesDelete, doSetPinning, onRemotePinClick, doPublishIpnsKey,
-  files, filesPathInfo, filesIsFetching, pinningServices, toursEnabled, handleJoyrideCallback, isCliTutorModeEnabled, cliOptions, filesSorting, t
+  files, pins, filesPathInfo, filesIsFetching, pinningServices, toursEnabled, handleJoyrideCallback, isCliTutorModeEnabled, cliOptions, filesSorting, t
 }) => {
   const { doExploreUserProvidedPath } = useExplore()
   const contextMenuRef = useRef()
@@ -219,10 +219,10 @@ const FilesPage = ({
         .filter(n => n)
         .map(file => ({
           ...file,
-          pinned: files?.pins?.map(p => p.toString())?.includes(file.cid.toString())
+          pinned: (pins || []).includes(file.cid.toString())
         }))
         /* eslint-disable-next-line react-hooks/exhaustive-deps */
-    , [files?.content, files?.pins, selected])
+    , [files?.content, pins, selected])
 
     if (!files || files.type === 'file') return null
     // if file not found
@@ -251,7 +251,7 @@ const FilesPage = ({
     const commonProps = {
       updateSorting: doFilesUpdateSorting,
       files: files.content || [],
-      pins: files.pins || [],
+      pins: pins || [],
       remotePins: remotePins || [],
       pendingPins: pendingPins || [],
       failedPins: failedPins || [],
@@ -454,6 +454,7 @@ export default connect(
   'selectIpfsProvider',
   'selectIpfsConnected',
   'selectFiles',
+  'selectPins',
   'selectFilesIsFetching',
   'selectRemotePins',
   'selectPendingPins',


### PR DESCRIPTION
## Problem

It was impossible to also unpin while removing more than one file. 

### Why

FilesPage never connected to `selectPins`, so it read `files?.pins` (i.e. `pageContent.pins`, always undefined) when computing `pinned` for batch-selected items. Every batch item ended up with `pinned: false`, so RemoveModal's `files.some(f => f.pinned)` was false and the "Also remove local pin" checkbox stayed hidden. Single-file context-menu delete worked because it gets `pinned` from <File> rows in FilesList, which does connect `selectPins`.

## Fix (this PR)

Wire `selectPins` into FilesPage and use it in `selectedFiles` and `commonProps.pins`. `state.files.pins` is already `string[]` (the reducer does `.map(String)`), so no per-element `toString()` is needed. The delete action already short-circuits unpin for non-pinned items and wraps `ipfs.pin.rm` in best-effort try/catch, so mixed pinned/unpinned selections are handled idempotently.

- Fixes https://github.com/ipfs/ipfs-webui/issues/2487

## Preview

> <img width="1205" height="589" alt="image" src="https://github.com/user-attachments/assets/ec940fff-55d5-419e-a99d-40041b532ba6" />
