### PR TITLE
chore: update GitHub Actions references

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Attach produced build to Github Action
         # only re-upload if we re-built
         if: steps.build-cache.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ipfs-webui_${{ github.sha }}-${{ runner.os }}-build
           path: build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: |
           ipfs dag export ${{ steps.ipfs.outputs.cid }} > ipfs-webui_${{ github.sha }}.car
       - name: Attach produced build to Github Action
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: ipfs-webui_${{ github.sha }}.car
           path: ipfs-webui_${{ github.sha }}.car
@@ -162,7 +162,7 @@ jobs:
       - name: Fail job due to pinning failure
         # only fail if pinning failed for main commits
         if: github.ref == 'refs/heads/main' && steps.pin-w3up.outcome == 'failure' && steps.pin-cluster.outcome == 'failure'
-        uses: actions/github-script@v8
+        uses: actions/github-script@v9
         with:
           script: |
               core.setFailed('Pinning did not succeed')
@@ -315,7 +315,7 @@ jobs:
         run: npm ci --prefer-offline --no-audit --progress=false
 
       - name: Download CAR artifact
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: ipfs-webui_${{ github.sha }}.car
 

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: "Reset ${{ inputs.gh-node-version }} badge"
         if: github.ref == 'refs/heads/main'
-        uses: RubbaBoy/BYOB@24f464284c1fd32028524b59607d417a2e36fee7
+        uses: RubbaBoy/BYOB@a4919104bc0ec7cfd7f113e42c405cc45246f2a4
         with:
           icon: https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg
           name: "node-${{ inputs.gh-node-version }}"
@@ -71,7 +71,7 @@ jobs:
     steps:
       - name: Create success badge
         if: ${{ needs.test-node.result == 'success' && github.ref == 'refs/heads/main' }}
-        uses: RubbaBoy/BYOB@24f464284c1fd32028524b59607d417a2e36fee7
+        uses: RubbaBoy/BYOB@a4919104bc0ec7cfd7f113e42c405cc45246f2a4
         with:
           icon: https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg
           name: "node-${{ inputs.gh-node-version }}"
@@ -82,7 +82,7 @@ jobs:
 
       - name: Create failure badge
         if: ${{ needs.test-node.result != 'success' && github.ref == 'refs/heads/main' }}
-        uses: RubbaBoy/BYOB@24f464284c1fd32028524b59607d417a2e36fee7
+        uses: RubbaBoy/BYOB@a4919104bc0ec7cfd7f113e42c405cc45246f2a4
         with:
           icon: https://raw.githubusercontent.com/devicons/devicon/master/icons/nodejs/nodejs-original.svg
           name: "node-${{ inputs.gh-node-version }}"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -113,7 +113,7 @@ jobs:
 
       - name: Store Artifacts from Failed Tests
         if: failure()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: test-results
           path: test-results/
@@ -158,7 +158,7 @@ jobs:
         id: coverage
         run: npx nyc report --reporter=lcov
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: e2e_tests

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Run test-storybook:ci
         run: npm run test-storybook:ci
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: storybook_tests

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -34,7 +34,7 @@ jobs:
         id: coverage
         run: npx nyc report --reporter=lcov
 
-      - uses: codecov/codecov-action@v5
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           flags: unit_tests

--- a/.github/workflows/tx-pull.yml
+++ b/.github/workflows/tx-pull.yml
@@ -12,7 +12,7 @@ jobs:
   tx-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup i18n-sync branch
         run: |
           # Fetch i18n-sync branch if it exists remotely


### PR DESCRIPTION
Updates GitHub Actions used by workflow files to their latest available references while preserving each pin's existing specificity level. This includes newer artifact, GitHub Script, Codecov, checkout, and BYOB references. Verified all workflow YAML files parse successfully.