### PR TITLE
fix(files): blank screen when navigating mid-load

### DIFF
--- a/src/bundles/files/actions.js
+++ b/src/bundles/files/actions.js
@@ -191,8 +191,20 @@ const actions = () => ({
     const isConnected = store.selectIpfsConnected()
     const isFetching = store.selectFilesIsFetching()
     const info = store.selectFilesPathInfo()
-    if (isReady && isConnected && !isFetching && info) {
+    if (!isReady || !isConnected || !info || isFetching) return
+
+    try {
       await store.doFetch(info)
+    } finally {
+      // Navigating away while a listing is in flight makes that navigation's own
+      // doFilesFetch() a no-op, because of the isFetching check above, and
+      // nothing else retries it. Without this the view keeps waiting on content
+      // for a path we already left. Runs on failure too, since a rejected fetch
+      // leaves the new path just as unfetched.
+      const current = store.selectFilesPathInfo()
+      if (current && current.path !== info.path) {
+        await store.doFilesFetch()
+      }
     }
   },
 


### PR DESCRIPTION
## Problem

Open a folder that is slow to list, click through to another path before it finishes, and you land on a blank screen: no listing, and for a path that does not exist, not even the error page. It stays blank until you navigate somewhere else.

`doFilesFetch` skips its work while another listing is in flight, and the navigation's own call is exactly that. Nothing retries it, so the view still holds content for the path you left, and the stale-path guard in `MainView` rightly refuses to render it.

## Fix

- Once the in-flight fetch settles, re-check the route and fetch the new path if it moved
- Runs on failure too, since a rejected fetch leaves the new path just as unfetched

The guard from #2437 stays as it is: it was doing the right thing, and the fetch it was waiting on never came. Still one listing at a time, so no extra concurrent requests.